### PR TITLE
feat(ci/cd): Add Github actions with multiarch support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,70 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_REPO: ${{ format('{0}/{1}', 'ghcr.io', github.repository) }}
+  IMAGE_TAG: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.number, github.sha) || github.sha }}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push image (${{ matrix.arch }})
+      env:
+        IMAGE_TAG: ${{ env.IMAGE_TAG }}-${{ matrix.arch }}
+      run: |
+        make oci-build
+        make oci-push
+
+  manifest:
+    needs: build
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create and push manifest
+      run: |
+        make oci-manifest-build
+        make oci-manifest-push
+
+    - name: Tag as latest (main branch only)
+      if: github.ref == 'refs/heads/main'
+      run: |
+        make oci-tag
+        make oci-push
+      env:
+        IMAGE_TAG: latest

--- a/README.md
+++ b/README.md
@@ -36,11 +36,32 @@ To manage Openshift / K8s integration claudio will use https://github.com/contai
 
 # Build
 
-To build the container with latest dbs run the command:
+To build the container run the command:
 
 ```bash
 make oci-build
 ```
+
+This builds for the native architecture of the current platform.
+
+You can customize the image name and tag:
+
+```bash
+IMAGE_REPO=ghcr.io/myorg/claudio IMAGE_TAG=latest make oci-build
+```
+
+By default, the Makefile uses Podman. To use Docker instead:
+
+```bash
+CONTAINER_MANAGER=docker make oci-build
+```
+
+Available targets:
+- `oci-build` - Build container image for native architecture
+- `oci-push` - Push container image
+- `oci-tag` - Tag existing image with new tag
+- `oci-manifest-build` - Create multi-arch manifest from arch-tagged images
+- `oci-manifest-push` - Push manifest to registry
 
 # Usage
 
@@ -49,14 +70,14 @@ Claudio sample usage:
 ```bash
 # Create a volume to hold the auth for gcloud
 podman volume create claudio-gcp
-        
+
 # Create a volume to hold cache for mcp slack
 podman volume create claudio-mcp-slack
 
 # Run claudio
 podman run -it --rm \
         # Optional
-        -v claudio-gcp:/root/.config/gcloud:Z \ 
+        -v claudio-gcp:/root/.config/gcloud:Z \
         # Optional
         -v claudio-mcp-slack:/root/claude/mcp/slack:Z \
         -e GITLAB_URL='https://gitlab.com' \


### PR DESCRIPTION
This PR enables Github actions pipeline with support to multiarch builds. It creates and pushes images for main and for PRs for amd64 and arm64 arches.

- add a Github actions workflow to enable continuous integration and delivery, images pushed to Github's repository
- Updates Makefile to use localhost's platform, removes arch-specific builds (leverages CI builds instead)
- update README with tip for Docker users

fixes #3 #12 