### PR TITLE
fix: gh action tag env overriding actual tag while push from main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,9 @@ jobs:
         make oci-manifest-push
 
     - name: Tag as latest (main branch only)
-      if: github.ref == 'refs/heads/main'
+      if: github.event_name == 'push'
       run: |
         make oci-tag
         make oci-push
       env:
-        IMAGE_TAG: latest
+        IMAGE_TARGET_TAG: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,21 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push image (${{ matrix.arch }})
+    - name: Build image (${{ matrix.arch }})
       env:
         IMAGE_TAG: ${{ env.IMAGE_TAG }}-${{ matrix.arch }}
       run: |
         make oci-build
+
+    - name: Push image (${{ matrix.arch }})
+      if: github.event_name == 'push'
+      env:
+        IMAGE_TAG: ${{ env.IMAGE_TAG }}-${{ matrix.arch }}
+      run: |
         make oci-push
 
   manifest:
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-24.04
 
@@ -62,7 +69,6 @@ jobs:
         make oci-manifest-push
 
     - name: Tag as latest (main branch only)
-      if: github.event_name == 'push'
       run: |
         make oci-tag
         make oci-push

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ oci-manifest-push:
 	${CONTAINER_MANAGER} manifest push $(IMAGE_NAME)
 
 oci-tag:
-	${CONTAINER_MANAGER} tag $(IMAGE_NAME) $(IMAGE_REPO):$(IMAGE_TAG)
+	${CONTAINER_MANAGER} tag $(IMAGE_NAME) $(IMAGE_REPO):$(IMAGE_TARGET_TAG)
 
 oci-push:
 	${CONTAINER_MANAGER} push $(IMAGE_NAME)


### PR DESCRIPTION
Previously it used IMAGE_TAG for both source and target tags when tagging for push latest commit to main. This will add a new ENV to set the TARGET_TAG. Fixes #19.