### PR TITLE
fix: Missing default permissions for gitlab mcp

### DIFF
--- a/conf/.claude/settings.json
+++ b/conf/.claude/settings.json
@@ -4,7 +4,11 @@
       "mcp__slack__conversations_history",
       "mcp__slack__channels_list",
       "mcp__slack__conversations_search_messages",
-      "mcp__slack__conversations_add_message"
+      "mcp__slack__conversations_add_message",
+      "mcp__gitlab__list_project_merge_requests",
+      "mcp__gitlab__get_merge_request",
+      "mcp__gitlab__get_job",
+      "mcp__gitlab__list_group_merge_requests"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
When running claudio in single prompt mode it requires permissions already granted. This add a basic set of fucntions from gitlab mcp as allowed. 

Fix #26