### PR TITLE
fix: update method to get pr number in push-pr-images

### DIFF
--- a/.github/workflows/push-pr-images.yml
+++ b/.github/workflows/push-pr-images.yml
@@ -57,17 +57,19 @@ jobs:
       - name: Get PR details
         id: pr
         run: |
-          # Extract PR number and head SHA from workflow_run event
-          PR_NUMBER=$(jq -r '.pull_requests[0].number' <<< '${{ toJson(github.event.workflow_run) }}')
-          HEAD_SHA=$(jq -r '.pull_requests[0].head.sha' <<< '${{ toJson(github.event.workflow_run) }}')
+          # Extract PR number from image tag (format: pr-123)
+          PR_NUMBER=$(echo "${{ env.image }}" | grep -oP 'pr-\K\d+')
+
+          # Get head SHA from workflow_run event (always available)
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
 
           # Validate extracted values
-          if [ "$PR_NUMBER" = "null" ] || [ -z "$PR_NUMBER" ]; then
-            echo "Error: Failed to extract PR number from workflow_run event"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Error: Failed to extract PR number from image name: ${{ env.image }}"
             exit 1
           fi
-          if [ "$HEAD_SHA" = "null" ] || [ -z "$HEAD_SHA" ]; then
-            echo "Error: Failed to extract HEAD SHA from workflow_run event"
+          if [ -z "$HEAD_SHA" ]; then
+            echo "Error: HEAD SHA not available in workflow_run event"
             exit 1
           fi
 


### PR DESCRIPTION
Apparently the "pull_request" field is not populated on PRs from forks but we have the PR number in the image already from the other workflow.