### PR TITLE
INTERNAL: Updated old quay registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Vim swap files
+*.swp
+.swp

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERSION ?= 1.0.0-dev
 CONTAINER_MANAGER ?= podman
 
 # Image configuration
-IMAGE_REPO ?= quay.io/redhat-aipcc/claudio
+IMAGE_REPO ?= quay.io/aipcc-cicd/claudio
 IMAGE_TAG ?= v${VERSION}
 IMAGE_NAME ?= $(IMAGE_REPO):$(IMAGE_TAG)
 IMAGE_SOURCE_TAG ?= $(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ podman run -it --rm --user 0 \
         -e SLACK_MCP_XOXC_TOKEN='xoxc-...' \
         -e SLACK_MCP_XOXD_TOKEN='xoxd-...' \
         -e K8S_MCP_KUBECONFIG_PATH=/opt/k8s/kubeconfig \
-        quay.io/redhat-aipcc/claudio:v1.0.0-dev
+        quay.io/aipcc-cicd/claudio:v1.0.0-dev
 ```
 
 Claudio on a host where user is already logged in on gcloud:
@@ -107,7 +107,7 @@ podman run -it --rm -user 0 \
         -e SLACK_MCP_XOXC_TOKEN='xoxc-...' \
         -e SLACK_MCP_XOXD_TOKEN='xoxd-...' \
         -e K8S_MCP_KUBECONFIG_PATH=/opt/k8s/kubeconfig \
-        quay.io/redhat-aipcc/claudio:v1.0.0-dev
+        quay.io/aipcc-cicd/claudio:v1.0.0-dev
 ```
 
 Claudio one-time prompt
@@ -124,6 +124,6 @@ podman run -it --rm -user 0 \
         -e SLACK_MCP_XOXC_TOKEN='xoxc-...' \
         -e SLACK_MCP_XOXD_TOKEN='xoxd-...' \
         -e K8S_MCP_KUBECONFIG_PATH=/opt/k8s/kubeconfig \
-        quay.io/redhat-aipcc/claudio:v1.0.0-dev \
+        quay.io/aipcc-cicd/claudio:v1.0.0-dev \
                 -p "do something for me Claudio"
 ```


### PR DESCRIPTION
Updated all the old references to the wrong quay.io/redhat-aipcc/claudio registry, and switched to the new aipcc-cicd/claudio. Also added a minimal .gitignore file.