### PR TITLE
feat: Replacing mcp with skills

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -51,17 +51,31 @@ ENV SLACK_MCP_CUSTOM_TLS=1 \
     SLACK_MCP_USERS_CACHE=${HOME}/claude/mcp/slack/.users_cache.json \
     SLACK_MCP_CHANNELS_CACHE=${HOME}/claude/mcp/slack/.channels_cache_v2.json
 
-# Gitlab
-# https://github.com/zereight/gitlab-mcp/releases
-ENV GITLAB_MCP_V 2.0.11
+# Glab CLI
+# https://gitlab.com/gitlab-org/cli/-/releases
+ENV GLAB_V 1.78.3
+RUN curl -L https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_V}/downloads/glab_${GLAB_V}_linux_${TARGETARCH}.rpm -o glab.rpm && \
+    dnf install -y ./glab.rpm && \
+    rm glab.rpm
 
-# K8s
-# https://github.com/containers/kubernetes-mcp-server/releases
-ENV K8S_MCP_V v0.0.54
+# Kubectl
+# https://kubernetes.io/releases/
+ENV KUBECTL_V 1.32.0
+RUN curl -L https://dl.k8s.io/release/v${KUBECTL_V}/bin/linux/${TARGETARCH}/kubectl -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
+# Claudio Skills
+# https://github.com/aipcc-cicd/claudio-skills/releases
+ENV CLAUDIO_SKILLS_V v0.1.0
 
 # Conf
 COPY conf/ ${HOME}/
+COPY scripts/ /usr/local/bin/
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Clone the skills marketplace and generate plugin configs (as root)
+RUN git clone --branch ${CLAUDIO_SKILLS_V} --depth 1 https://github.com/aipcc-cicd/claudio-skills.git ${HOME}/claudio-skills && \
+    /usr/local/bin/generate-plugin-configs.sh ${HOME}/claudio-skills ${HOME}/.claude/plugins
 
 # Setup non root user
 WORKDIR /home/default

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # claudio
 
-OCI image to make claude code portable; the model is being setup to use through Google Vertex AI API. 
+OCI image to make claude code portable; the model is being setup to use through Google Vertex AI API.
 
-The image also contains a list of curated mcp servers setup and a base memory for claude ensuring it uses them as expected. 
+The image includes the Slack MCP server for communication, along with `glab` and `kubectl` CLIs. Additional functionality is provided through the [claudio-skills marketplace](https://github.com/aipcc-cicd/claudio-skills).
 
 # Integrations
 
@@ -22,19 +22,15 @@ On Developer Tools go to:
 Since it is slack enterpise we need to get value for User-Agent. To get it from same place we check Networking and check request headers to get the value,
 it should be something similar to `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36`
 
-Disclaimer, the first time you reuse those Tokens you will probably be signed off as precaution, the second time you sign in the tokens should last. 
+Disclaimer, the first time you reuse those Tokens you will probably be signed off as precaution, the second time you sign in the tokens should last.
 
-## Gitlab CICD
+## GitLab
 
-To manage gitlab CICD integration claudio will use https://gitlab.com/fforster/gitlab-mcp 
+GitLab integration is provided through the `glab` CLI tool and the claudio-skills marketplace. The `glab` CLI is pre-installed in the container.
 
-For Auth check https://gitlab.com/fforster/gitlab-mcp#authentication
+## Kubernetes / OpenShift
 
-## Openshift / K8s 
-
-To manage Openshift / K8s integration claudio will use https://github.com/containers/kubernetes-mcp-server
-
-We will need to add the kubeconfig as part of the execution and set its path with `K8S_MCP_KUBECONFIG_PATH`
+Kubernetes and OpenShift management is handled through `kubectl` (pre-installed) and skills from the claudio-skills marketplace.
 
 # Build
 
@@ -80,7 +76,6 @@ podman run -it --rm --user 0 \
         -v ${PWD}:/home/default/workdir:z \
         -v claudio-gcp:/root/.config/gcloud:Z \
         -v claudio-mcp-slack:/root/claude/mcp/slack:Z \
-        -e GITLAB_URL='https://gitlab.com' \
         -e GITLAB_TOKEN='...' \
         -e ANTHROPIC_VERTEX_PROJECT_ID=... \
         -e ANTHROPIC_VERTEX_PROJECT_QUOTA=... \
@@ -108,7 +103,6 @@ podman run -it --rm --user 0 \
         -v claudio-gcp:/root/.config/gcloud:Z \
         # Optional
         -v claudio-mcp-slack:/root/claude/mcp/slack:Z \
-        -e GITLAB_URL='https://gitlab.com' \
         -e GITLAB_TOKEN='...' \
         -e ANTHROPIC_VERTEX_PROJECT_ID=... \
         -e ANTHROPIC_VERTEX_PROJECT_QUOTA=... \
@@ -125,7 +119,6 @@ Claudio on a host where user is already logged in on gcloud:
 podman run -it --rm -user 0 \
         -v ${PWD}/kubecofing:/opt/k8s/kubeconfig:z \
         -v /home/$USER/.conf/gcloud:/root/.config/gcloud:z \
-        -e GITLAB_URL='https://gitlab.com' \
         -e GITLAB_TOKEN='...' \
         -e ANTHROPIC_VERTEX_PROJECT_ID=... \
         -e ANTHROPIC_VERTEX_PROJECT_QUOTA=... \
@@ -142,7 +135,6 @@ Claudio one-time prompt
 podman run -it --rm -user 0 \
         -v ${PWD}/kubecofing:/opt/k8s/kubeconfig:z \
         -v /home/$USER/.conf/gcloud:/root/.config/gcloud:z \
-        -e GITLAB_URL='https://gitlab.com' \
         -e GITLAB_TOKEN='...' \
         -e ANTHROPIC_VERTEX_PROJECT_ID=... \
         -e ANTHROPIC_VERTEX_PROJECT_QUOTA=... \

--- a/conf/.claude.json
+++ b/conf/.claude.json
@@ -6,7 +6,7 @@
     "tengu_disable_bypass_permissions_mode": false
   },
   "projects": {
-    "/": {
+    "/home/default/workdir": {
       "allowedTools": [],
       "history": [],
       "mcpContextUris": [],

--- a/conf/.claude/context.d/CLAUDE-base.md
+++ b/conf/.claude/context.d/CLAUDE-base.md
@@ -1,8 +1,8 @@
 # Sequential Thinking Memory
 - To inspect container images or container registries you can skopeo 
-- To interact with k8s / OpenShift Cluster you can use your k8s mcp server
+- To interact with k8s / OpenShift Cluster you can use your kubernetes skill
 - To interact with slack you can use your slack mcp server
-- To interact with gitlab you can use your gitlab mcp server
+- To interact with gitlab you can use your gitlab skill
 - Before giving a final answer, summarize reasoning and list assumptions.
 - When coding, first outline the approach → then show the code → then explain potential pitfalls.
 - Carry forward context from earlier turns unless I override it.

--- a/conf/.claude/mcp.d/mcp-base.json
+++ b/conf/.claude/mcp.d/mcp-base.json
@@ -17,30 +17,6 @@
         "SLACK_MCP_CHANNELS_CACHE": "${SLACK_MCP_CHANNELS_CACHE}",
         "SLACK_MCP_ADD_MESSAGE_TOOL":"true"
       }
-    },
-    "gitlab": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@zereight/mcp-gitlab@${GITLAB_MCP_V}"
-      ],
-      "env": {
-        "GITLAB_PERSONAL_ACCESS_TOKEN": "${GITLAB_TOKEN}",
-        "GITLAB_API_URL": "${GITLAB_URL}",
-        "USE_PIPELINE": "true"
-      }
-    },
-    "k8s": {
-      "command": "npx",
-      "args": [
-        "-y", 
-        "kubernetes-mcp-server@${K8S_MCP_V}",
-        "--kubeconfig",
-        "${K8S_MCP_KUBECONFIG_PATH}",
-        "--disable-destructive",
-        "--toolsets",
-        "core"
-      ]
     }
   }
 }

--- a/conf/.claude/settings.json
+++ b/conf/.claude/settings.json
@@ -5,15 +5,22 @@
       "mcp__slack__channels_list",
       "mcp__slack__conversations_search_messages",
       "mcp__slack__conversations_add_message",
-      "mcp__gitlab__get_commit",
-      "mcp__gitlab__list_merge_requests",
-      "mcp__gitlab__get_merge_request",
-      "mcp__gitlab__get_pipeline",
-      "mcp__gitlab__get_pipeline_job",
-      "mcp__k8s__resources_list",
-      "mcp__k8s__resources_get"
+      "Skill(claudio-plugin:gitlab)",
+      "Skill(claudio-plugin:konflux)",
+      "Skill(claudio-plugin:kubernetes)"
     ],
     "deny": [],
     "ask": []
+  },
+  "extraKnownMarketplaces": {
+    "claudio-skills": {
+      "source": {
+        "source": "directory",
+        "path": "/home/default/claudio-skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "claudio-plugin@claudio-skills": true
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -33,46 +33,45 @@
     },
     {
       "customType": "regex",
-      "description": "Update Slack MCP server version",
+      "description": "Update glab CLI version",
       "managerFilePatterns": [
         "Containerfile"
       ],
       "matchStrings": [
-        "ENV\\s+SLACK_MCP_V\\s+v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "ENV\\s+GLAB_V\\s+(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "korotovsky/slack-mcp-server",
+      "depNameTemplate": "gitlab-org/cli",
       "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$",
-      "versioningTemplate": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "autoReplaceStringTemplate": "ENV SLACK_MCP_V v{{newVersion}}"
+      "autoReplaceStringTemplate": "ENV GLAB_V {{newVersion}}"
     },
     {
       "customType": "regex",
-      "description": "Update GitLab MCP npm package version",
+      "description": "Update kubectl version",
       "managerFilePatterns": [
         "Containerfile"
       ],
       "matchStrings": [
-        "ENV\\s+GITLAB_MCP_V\\s+(?<currentValue>\\d+\\.\\d+\\.\\d+)"
-      ],
-      "datasourceTemplate": "npm",
-      "depNameTemplate": "@zereight/mcp-gitlab",
-      "autoReplaceStringTemplate": "ENV GITLAB_MCP_V {{newValue}}"
-    },
-    {
-      "customType": "regex",
-      "description": "Update Kubernetes MCP server version",
-      "managerFilePatterns": [
-        "Containerfile"
-      ],
-      "matchStrings": [
-        "ENV\\s+K8S_MCP_V\\s+v(?<currentValue>\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)"
+        "ENV\\s+KUBECTL_V\\s+(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "containers/kubernetes-mcp-server",
-      "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?)$",
-      "versioningTemplate": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-[0-9A-Za-z.-]+)?$",
-      "autoReplaceStringTemplate": "ENV K8S_MCP_V v{{newVersion}}"
+      "depNameTemplate": "kubernetes/kubernetes",
+      "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$",
+      "autoReplaceStringTemplate": "ENV KUBECTL_V {{newVersion}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Claudio Skills version",
+      "managerFilePatterns": [
+        "Containerfile"
+      ],
+      "matchStrings": [
+        "ENV\\s+CLAUDIO_SKILLS_V\\s+v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "aipcc-cicd/claudio-skills",
+      "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$",
+      "autoReplaceStringTemplate": "ENV CLAUDIO_SKILLS_V v{{newVersion}}"
     }
   ],
   "packageRules": []

--- a/scripts/generate-plugin-configs.sh
+++ b/scripts/generate-plugin-configs.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+MARKETPLACE_DIR="${1:-/home/default/claudio-skills}"
+CONFIG_DIR="${2:-/home/default/.claude/plugins}"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+
+# Read marketplace metadata
+MARKETPLACE_JSON="${MARKETPLACE_DIR}/.claude-plugin/marketplace.json"
+if [ ! -f "$MARKETPLACE_JSON" ]; then
+    echo "Error: Marketplace metadata not found at $MARKETPLACE_JSON"
+    exit 1
+fi
+
+MARKETPLACE_NAME=$(jq -r '.name' "$MARKETPLACE_JSON")
+
+# Build installed_plugins.json using process substitution to avoid subshell issues
+INSTALLED_PLUGINS='{"version":1,"plugins":{}}'
+
+while IFS= read -r plugin_source; do
+    plugin_name=$(echo "$plugin_source" | jq -r '.name')
+    plugin_path=$(echo "$plugin_source" | jq -r '.source')
+
+    # Read plugin metadata
+    plugin_json="${MARKETPLACE_DIR}/${plugin_path}/.claude-plugin/plugin.json"
+    if [ ! -f "$plugin_json" ]; then
+        echo "Warning: Plugin metadata not found at $plugin_json, skipping..."
+        continue
+    fi
+
+    plugin_version=$(jq -r '.version' "$plugin_json")
+    plugin_install_path="${MARKETPLACE_DIR}/${plugin_path}"
+    plugin_key="${plugin_name}@${MARKETPLACE_NAME}"
+
+    # Add to installed_plugins
+    INSTALLED_PLUGINS=$(echo "$INSTALLED_PLUGINS" | jq \
+        --arg key "$plugin_key" \
+        --arg version "$plugin_version" \
+        --arg timestamp "$TIMESTAMP" \
+        --arg path "$plugin_install_path" \
+        '.plugins[$key] = {
+            "version": $version,
+            "installedAt": $timestamp,
+            "lastUpdated": $timestamp,
+            "installPath": $path,
+            "isLocal": true
+        }')
+done < <(jq -c '.plugins[]' "$MARKETPLACE_JSON")
+
+# Build known_marketplaces.json
+KNOWN_MARKETPLACES=$(jq -n \
+    --arg name "$MARKETPLACE_NAME" \
+    --arg path "$MARKETPLACE_DIR" \
+    --arg timestamp "$TIMESTAMP" \
+    '{
+        ($name): {
+            "source": {
+                "source": "directory",
+                "path": $path
+            },
+            "installLocation": $path,
+            "lastUpdated": $timestamp
+        }
+    }')
+
+# Ensure config directory exists
+mkdir -p "$CONFIG_DIR"
+
+# Write config files
+echo "$INSTALLED_PLUGINS" | jq '.' > "${CONFIG_DIR}/installed_plugins.json"
+echo "$KNOWN_MARKETPLACES" | jq '.' > "${CONFIG_DIR}/known_marketplaces.json"
+
+echo "Generated plugin configs in ${CONFIG_DIR}"
+echo "- Installed plugins: $(echo "$INSTALLED_PLUGINS" | jq -r '.plugins | keys | length') plugin(s)"
+echo "- Known marketplaces: ${MARKETPLACE_NAME}"


### PR DESCRIPTION
Replacing gitlab and k8s mcp servers with skills. The marketplace is dynamically cloned and configured during container build.
Needs https://github.com/aipcc-cicd/claudio-skills/pull/2 