### PR TITLE
feat: allow konflux-release-skill

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -56,7 +56,7 @@ USER root
 ENV HOME /home/claudio
 
 # Base for claudio image
-RUN microdnf install -y skopeo podman unzip gzip; \
+RUN microdnf install -y skopeo podman unzip gzip git; \
     useradd claudio; \
     chown -R claudio:0 ${HOME}; \
     chmod -R ug+rwx ${HOME}

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,13 @@ CS_REF ?= main
 # CS_REF ?= v0.1.0
 
 # Build actions
-.PHONY: oci-build oci-save oci-load oci-push-arch oci-manifest-build oci-manifest-push oci-tag oci-push
+.PHONY: oci-build oci-rebuild oci-save oci-load oci-push-arch oci-manifest-build oci-manifest-push oci-tag oci-push
 
 oci-build:
+	${CONTAINER_MANAGER} build --build-arg CS_REF=$(CS_REF) --build-arg CS_REF_TYPE=$(CS_REF_TYPE) -t $(IMAGE_NAME) .
+
+oci-rebuild:
+	${CONTAINER_MANAGER} rmi ${IMAGE_NAME}
 	${CONTAINER_MANAGER} build --build-arg CS_REF=$(CS_REF) --build-arg CS_REF_TYPE=$(CS_REF_TYPE) -t $(IMAGE_NAME) .
 
 oci-save:

--- a/conf/.claude/context.d/CLAUDE-base.md
+++ b/conf/.claude/context.d/CLAUDE-base.md
@@ -1,6 +1,7 @@
 # Sequential Thinking Memory
-- To inspect container images or container registries you can skopeo 
-- To interact with k8s / OpenShift Cluster you can use your kubernetes skill
+- To inspect container images or container registries you can use skopeo
+- To interact with k8s / OpenShift Cluster you can use kubectl
+- To create Konflux production releases you can use your konflux-release skill
 - To interact with slack you can use your slack mcp server
 - To interact with gitlab you can use your gitlab skill
 - Before giving a final answer, summarize reasoning and list assumptions.

--- a/conf/.claude/settings.json
+++ b/conf/.claude/settings.json
@@ -1,9 +1,13 @@
 {
+  "model": "claude-sonnet-4-6",
   "permissions": {
     "allow": [
-      "Skill(claudio-plugin:gitlab)",
-      "Skill(claudio-plugin:konflux)",
-      "Skill(claudio-plugin:kubernetes)"
+      "Skill(claudio-plugin:aws-log-analyzer)",
+      "Skill(claudio-plugin:gitlab-job-analyzer)",
+      "Skill(claudio-plugin:konflux-release)",
+      "Skill(claudio-plugin:slack-utilities)",
+      "Bash(ls *)",
+      "Read(//home/claudio/.claude/**)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
Adding permissions for new konflux-release skill and letting skopeo be
installed by the tools script form the skill.
Adding oci-rebuild target for local development.
Setting "sonnet-4-6" as default model.
Some permission update.s

This requires https://github.com/aipcc-cicd/claudio-skills/pull/4 and then a new tagged release so we can update the version here.