### PR TITLE
Add reusable GitLab CI template for running claudio jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,9 @@ oci-tag:
 
 oci-push:
 	${CONTAINER_MANAGER} push $(IMAGE_NAME)
+
+# Integrations
+.PHONY: integrations-update
+
+integrations-update:
+	sed -e 's%<IMAGE>%$(IMAGE_NAME)%g' integrations/gitlab-ci/template/claudio.yml > integrations/gitlab-ci/claudio.yml

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Available targets:
 - `oci-tag` - Tag existing image with new tag
 - `oci-manifest-build` - Create multi-arch manifest from arch-tagged images
 - `oci-manifest-push` - Push manifest to registry
+- `integrations-update` - Regenerate CI templates with current image version
 
 ## Claudio Skills Reference
 
@@ -141,3 +142,29 @@ claudio
 ```bash
 claudio -p "do something for me Claudio"
 ```
+
+## GitLab CI Integration
+
+Claudio provides a reusable GitLab CI template for running claudio jobs in your pipelines. Include it in your project's `.gitlab-ci.yml`:
+
+```yaml
+include:
+  - project: 'aipcc-cicd/claudio'
+    file: 'integrations/gitlab-ci/claudio.yml'
+
+my-claudio-job:
+  extends: .claudio
+  variables:
+    CLAUDIO_PROMPT: "Analyze the latest MRs and report to Slack"
+```
+
+The `.claudio` template uses the claudio image directly as the job container. You just set `CLAUDIO_PROMPT` and claudio runs with the entrypoint handling gcloud auth and setup.
+
+Available variables:
+- `CLAUDIO_PROMPT` (required) — the prompt to run
+- `CLAUDIO_IMAGE` — override the claudio image (default: current release version)
+- `CLAUDIO_EXTRA_ARGS` — extra arguments passed to claudio
+
+The template is generated from `integrations/gitlab-ci/template/claudio.yml`. When preparing a release, run `make integrations-update` to regenerate the template with the current version, then commit the result.
+
+Downstream projects can extend this template to add their own secret management.

--- a/integrations/gitlab-ci/claudio.yml
+++ b/integrations/gitlab-ci/claudio.yml
@@ -1,0 +1,35 @@
+# Reusable GitLab CI template for running claudio jobs.
+#
+# Include this template in your project's .gitlab-ci.yml:
+#
+#   include:
+#     - project: 'aipcc-cicd/claudio'
+#       file: 'integrations/gitlab-ci/claudio.yml'
+#
+# Then define a job that extends .claudio:
+#
+#   my-claudio-job:
+#     extends: .claudio
+#     variables:
+#       CLAUDIO_PROMPT: "Analyze the latest MRs and report to Slack"
+#
+# Optional variables to override:
+#   CLAUDIO_IMAGE       - claudio container image (default: quay.io/aipcc-cicd/claudio:<VERSION>)
+#   CLAUDIO_EXTRA_ARGS  - Extra arguments passed to claudio
+#
+
+.claudio:
+  image:
+    name: ${CLAUDIO_IMAGE}
+    entrypoint: [""]
+  variables:
+    CLAUDIO_IMAGE: "quay.io/aipcc-cicd/claudio:v0.5.0-dev"
+    CLAUDIO_EXTRA_ARGS: ""
+  script:
+    - |
+      if [ -z "${CLAUDIO_PROMPT}" ]; then
+        echo "ERROR: CLAUDIO_PROMPT variable is not set" >&2
+        exit 1
+      fi
+
+      entrypoint.sh -p "${CLAUDIO_PROMPT}" ${CLAUDIO_EXTRA_ARGS}

--- a/integrations/gitlab-ci/template/claudio.yml
+++ b/integrations/gitlab-ci/template/claudio.yml
@@ -1,0 +1,35 @@
+# Reusable GitLab CI template for running claudio jobs.
+#
+# Include this template in your project's .gitlab-ci.yml:
+#
+#   include:
+#     - project: 'aipcc-cicd/claudio'
+#       file: 'integrations/gitlab-ci/claudio.yml'
+#
+# Then define a job that extends .claudio:
+#
+#   my-claudio-job:
+#     extends: .claudio
+#     variables:
+#       CLAUDIO_PROMPT: "Analyze the latest MRs and report to Slack"
+#
+# Optional variables to override:
+#   CLAUDIO_IMAGE       - claudio container image (default: quay.io/aipcc-cicd/claudio:<VERSION>)
+#   CLAUDIO_EXTRA_ARGS  - Extra arguments passed to claudio
+#
+
+.claudio:
+  image:
+    name: ${CLAUDIO_IMAGE}
+    entrypoint: [""]
+  variables:
+    CLAUDIO_IMAGE: "<IMAGE>"
+    CLAUDIO_EXTRA_ARGS: ""
+  script:
+    - |
+      if [ -z "${CLAUDIO_PROMPT}" ]; then
+        echo "ERROR: CLAUDIO_PROMPT variable is not set" >&2
+        exit 1
+      fi
+
+      entrypoint.sh -p "${CLAUDIO_PROMPT}" ${CLAUDIO_EXTRA_ARGS}


### PR DESCRIPTION
## Summary
  - Add `integrations/gitlab-ci/claudio.yml` with a reusable `.claudio` job template
    that runs claudio directly as the CI job container
  - Pin image version with Renovate support for automated updates
  - Update README with CI integration docs

  ## Usage
  Projects can include the template and set a prompt:

      include:
        - project: 'aipcc-cicd/claudio'
          file: 'integrations/gitlab-ci/claudio.yml'

      my-job:
        extends: .claudio
        variables:
          CLAUDIO_PROMPT: "Do something"