### PR TITLE
feat: Parameterize git global configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ claudio
 claudio -p "do something for me Claudio"
 ```
 
+## Git Integration
+
+Git identity, commit signing, and remote authentication can be configured via environment variables. This is useful in CI pipelines and containerized environments where mounting `.gitconfig` is not practical.
+
+| Variable | Description |
+|---|---|
+| `GIT_USER_NAME` | Sets `git config --global user.name` |
+| `GIT_USER_EMAIL` | Sets `git config --global user.email` |
+| `GIT_SSH_SIGNING_KEY` | Path to an SSH key for commit signing. Enables `gpg.format ssh` and `commit.gpgsign true` |
+| `GITLAB_TOKEN` | GitLab personal access token, used by `glab` for API operations |
+| `GITLAB_HOST` | GitLab instance URL, used by `glab` (defaults to `gitlab.com`) |
+
+These are optional — if unset, git uses whatever config is already present (e.g. a mounted `.gitconfig`). This handles a single git identity. For multi-instance setups, configure per-host credentials in the configuration file (`~/.config/glab-cli/config.yml`).
+
 ## GitLab CI Integration
 
 Claudio provides a reusable GitLab CI template for running claudio jobs in your pipelines. Include it in your project's `.gitlab-ci.yml`:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ if [ "$DEBUG" = "true" ]; then
   set -x
 fi
 
-ADC_PATH="${HOME}/.config/gcloud/application_default_credentials.json"
+ADC_PATH="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
 
 ###################
 #### Functions ####
@@ -36,6 +36,21 @@ if ! check_adc; then
   # Setup project and quota
   gcloud config set project ${ANTHROPIC_VERTEX_PROJECT_ID}
   gcloud auth application-default set-quota-project ${ANTHROPIC_VERTEX_PROJECT_QUOTA}
+fi
+
+# Configure git identity (defaults can be overridden via env vars)
+if [ -n "${GIT_USER_NAME:-}" ]; then
+  git config --global user.name "$GIT_USER_NAME"
+fi
+if [ -n "${GIT_USER_EMAIL:-}" ]; then
+  git config --global user.email "$GIT_USER_EMAIL"
+fi
+
+# Configure git commit signing
+if [ -n "${GIT_SSH_SIGNING_KEY:-}" ]; then
+  git config --global gpg.format ssh
+  git config --global user.signingkey "$GIT_SSH_SIGNING_KEY"
+  git config --global commit.gpgsign true
 fi
 
 # Change to workdir if it exists (for mounted volumes)


### PR DESCRIPTION
Add optional env vars (GIT_USER_NAME, GIT_USER_EMAIL, GIT_SSH_SIGNING_KEY) to configure git identity and commit signing in the entrypoint. 