### PR TITLE
feat: auto-invalidate build cache when skills repo changes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,9 +20,23 @@ ARG TARGETARCH
 RUN dnf install -y git 
 
 
+# GCloud
+ENV GCLOUD_V 564.0.0
+ENV GCLOUD_BASE_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_V}"
+ENV GCLOUD_URL="${GCLOUD_BASE_URL}-linux-x86_64.tar.gz"
+RUN set -eux; \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        export GCLOUD_URL="${GCLOUD_BASE_URL}-linux-arm.tar.gz"; \
+    fi; \
+    curl -L "$GCLOUD_URL" -o gcloud.tar.gz; \
+    tar -xzf gcloud.tar.gz -C /opt;
+
 # Claudio Skills
 ARG CS_REF_TYPE
 ARG CS_REF
+# CS_CACHE_KEY is the resolved commit SHA — changing it invalidates the layer
+# cache so we always get fresh content when the remote ref updates.
+ARG CS_CACHE_KEY
 ENV CS_REPO https://github.com/aipcc-cicd/claudio-skills.git
 RUN set -eux; \
     git init claudio-skills; \
@@ -33,18 +47,7 @@ RUN set -eux; \
     else \
         git fetch --depth 1 origin "${CS_REF}"; \
     fi; \
-    git checkout FETCH_HEAD; 
-
-# GCloud
-ENV GCLOUD_V 564.0.0
-ENV GCLOUD_BASE_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_V}"
-ENV GCLOUD_URL="${GCLOUD_BASE_URL}-linux-x86_64.tar.gz"
-RUN set -eux; \
-    if [ "$TARGETARCH" = "arm64" ]; then \
-        export GCLOUD_URL="${GCLOUD_BASE_URL}-linux-arm.tar.gz"; \
-    fi; \
-    curl -L "$GCLOUD_URL" -o gcloud.tar.gz; \
-    tar -xzf gcloud.tar.gz -C /opt; 
+    git checkout FETCH_HEAD;
 
 # Claudio image    
 FROM registry.access.redhat.com/ubi10/python-312-minimal@sha256:3de23fb7f53a67937845591d68066d5f075a18826a6291dad2dd700cb1d4290a

--- a/Makefile
+++ b/Makefile
@@ -36,16 +36,22 @@ CS_REF ?= main
 # Example when we create a tag version for claudio
 # CS_REF_TYPE  ?= tag
 # CS_REF ?= v0.1.0
+CS_REPO ?= https://github.com/aipcc-cicd/claudio-skills.git
+
+# Resolve the remote HEAD SHA for the skills ref so the build cache
+# invalidates automatically when the PR/branch gets new commits.
+CS_CACHE_KEY_CMD = $(if $(filter pr,$(CS_REF_TYPE)), \
+	git ls-remote $(CS_REPO) "refs/pull/$(CS_REF)/head" | cut -f1, \
+	git ls-remote $(CS_REPO) "$(CS_REF)" | head -1 | cut -f1)
+CS_CACHE_KEY ?= $(shell $(CS_CACHE_KEY_CMD))
+
+CS_BUILD_ARGS = --build-arg CS_REF=$(CS_REF) --build-arg CS_REF_TYPE=$(CS_REF_TYPE) --build-arg CS_CACHE_KEY=$(CS_CACHE_KEY)
 
 # Build actions
-.PHONY: oci-build oci-rebuild oci-save oci-load oci-push-arch oci-manifest-build oci-manifest-push oci-tag oci-push
+.PHONY: oci-build oci-save oci-load oci-push-arch oci-manifest-build oci-manifest-push oci-tag oci-push
 
 oci-build:
-	${CONTAINER_MANAGER} build --build-arg CS_REF=$(CS_REF) --build-arg CS_REF_TYPE=$(CS_REF_TYPE) -t $(IMAGE_NAME) .
-
-oci-rebuild:
-	${CONTAINER_MANAGER} rmi ${IMAGE_NAME}
-	${CONTAINER_MANAGER} build --build-arg CS_REF=$(CS_REF) --build-arg CS_REF_TYPE=$(CS_REF_TYPE) -t $(IMAGE_NAME) .
+	${CONTAINER_MANAGER} build $(CS_BUILD_ARGS) -t $(IMAGE_NAME) .
 
 oci-save:
 	${CONTAINER_MANAGER} save -m -o $(ARTIFACT_NAME).tar $(IMAGE_NAME)


### PR DESCRIPTION
## Summary
- Resolve the remote HEAD SHA of the skills repo ref via `git ls-remote` before building, passing it as a `CS_CACHE_KEY` build arg to invalidate the layer cache only when the PR/branch gets new commits
- Reorder the preparer stage so GCloud is built before skills, keeping cache invalidation scoped to just the skills layer
- Remove `oci-rebuild` target as `oci-build` now handles cache correctly

## Test plan
- [ ] `make oci-build CS_REF_TYPE=pr CS_REF=<N>` builds and caches correctly
- [ ] Pushing new commits to the PR and re-running `make oci-build` rebuilds the skills layer but caches GCloud and other layers
- [ ] `make oci-build` with default `main` branch works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)