### PR TITLE
fix: chmod 600 SSH signing key before use

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,6 +48,7 @@ fi
 
 # Configure git commit signing
 if [ -n "${GIT_SSH_SIGNING_KEY:-}" ]; then
+  chmod 600 "$GIT_SSH_SIGNING_KEY"
   git config --global gpg.format ssh
   git config --global user.signingkey "$GIT_SSH_SIGNING_KEY"
   git config --global commit.gpgsign true


### PR DESCRIPTION
GitLab runner writes file-type CI variables with 0666 permissions. ssh-keygen refuses to use a private key that is world-readable, causing git commit signing to fail.