### PR TITLE
Pin default Haiku model to 4.5

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -67,6 +67,7 @@ RUN microdnf install -y skopeo podman unzip gzip git; \
 ENV CLAUDE_V 2.1.114
 ENV CLAUDE_CODE_USE_VERTEX=1 \
     CLOUD_ML_REGION=us-east5 \
+    ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5@20251001 \
     DISABLE_AUTOUPDATER=1
 ENV CLAUDE_BASE_URL="https://github.com/anthropics/claude-code/releases/download/v${CLAUDE_V}/claude-code-v${CLAUDE_V}"
 RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_V} && \


### PR DESCRIPTION
## Summary
- Add `ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5@20251001` env var to the Containerfile
- Previously the `haiku` alias resolved to Haiku 3.5 (`claude-3-5-haiku@20241022`) on Vertex AI — this pins it to Haiku 4.5
- Improves quality of Explore subagents and memsearch session summarization

## Test plan
- [ ] Build container image and verify env var is set
- [ ] Confirm `claude -p --model haiku` resolves to Haiku 4.5 inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)