### PR TITLE
fix: update GCP ML_REGION from us-east5 to global

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -66,7 +66,7 @@ RUN microdnf install -y skopeo podman unzip gzip git; \
 # https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
 ENV CLAUDE_V 2.1.116
 ENV CLAUDE_CODE_USE_VERTEX=1 \
-    CLOUD_ML_REGION=us-east5 \
+    CLOUD_ML_REGION=global \
     ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5@20251001 \
     DISABLE_AUTOUPDATER=1
 ENV CLAUDE_BASE_URL="https://github.com/anthropics/claude-code/releases/download/v${CLAUDE_V}/claude-code-v${CLAUDE_V}"


### PR DESCRIPTION
## Summary
- Update `CLOUD_ML_REGION` from `us-east5` to `global` in Containerfile

## Test plan
- [ ] Verify container builds successfully
- [ ] Verify Claude Code connects to Vertex AI using the global endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)