### PR TITLE
fix: configure HTTPS push credentials for gitlab.com

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,12 @@ if [ -n "${GIT_SSH_SIGNING_KEY:-}" ]; then
   git config --global commit.gpgsign true
 fi
 
+# Configure HTTPS push credentials for gitlab.com
+if [ -n "${GITLAB_TOKEN:-}" ]; then
+  git config --global credential."https://gitlab.com".helper \
+    '!f() { echo "username=oauth2"; echo "password=${GITLAB_TOKEN}"; }; f'
+fi
+
 # Change to workdir if it exists (for mounted volumes)
 if [ -d "$HOME/workdir" ]; then
   cd "$HOME/workdir"


### PR DESCRIPTION
## Summary

- Add a git credential helper scoped to `gitlab.com` when `GITLAB_TOKEN` is set
- Enables `git push origin` to work on the first attempt in CI environments
- Without this, CI jobs fall back through SSH (fails — key is for signing only) before eventually constructing `https://oauth2:$GITLAB_TOKEN@gitlab.com/...` manually

## Details

In GitLab CI, the default remote URL uses `$CI_JOB_TOKEN` which is read-only. The SSH key (`GIT_SSH_SIGNING_KEY`) is only for commit signing, not push auth. This leaves `GITLAB_TOKEN` as the only viable push credential, but nothing was wiring it into git's credential system.

The helper is scoped to `https://gitlab.com` so it does not affect:
- SSH-based auth (local dev with mounted SSH agent)
- Other git forges (github.com, gitlab.cee.redhat.com)

## Test plan

- [ ] Run a CI job that pushes a branch — verify push succeeds on first attempt
- [ ] Verify local `claudio` wrapper with SSH agent still works unchanged
- [ ] Verify jobs without `GITLAB_TOKEN` set are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Jakub Rusz <jrusz@redhat.com>