### PR TITLE
AIPCC-15313: fix: pin pyopenssl>=26.0.0 to address CVE-2026-27459

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -99,6 +99,10 @@ RUN set -eux; \
         "${HOME}/claudio-skills" \
         "${HOME}/.claude/plugins"
 
+# pyopenssl is pulled in transitively by the UBI10 base image and is not a direct
+# dependency. CVE-2026-27459 (CRITICAL) affects <26.0.0; pin the fixed version.
+RUN pip install --no-cache-dir "pyopenssl>=26.0.0"
+
 # Claudio
 RUN chown -R claudio:0 ${HOME}; \
     chmod -R ug+rwx ${HOME}


### PR DESCRIPTION
pyopenssl is pulled in transitively by the UBI10 base image and is not a direct dependency. CVE-2026-27459 (CRITICAL) affects versions <26.0.0. Pin the fixed version until UBI10 ships the update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patched a critical security vulnerability in the application's runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->