### PR TITLE
extract wrapper script from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,34 +82,11 @@ The recommended way to run claudio locally is through a wrapper script. It handl
 
 ## Wrapper Script Setup
 
-Create `~/.local/bin/claudio` with the following content and make it executable (`chmod +x`):
+Copy or symlink [`cli/claudio`](cli/claudio) to `~/.local/bin/claudio`:
 
 ```bash
-#!/bin/bash
-
-# Load environment variables from ~/.config/claudio/.env if it exists
-ENV_FILE="${HOME}/.config/claudio/.env"
-if [ -f "$ENV_FILE" ]; then
-  set -a
-  source "$ENV_FILE"
-  set +a
-fi
-
-podman run -it --rm --userns=keep-id \
-  -v ${HOME}/.kube/claudio-reader.kubeconfig:/home/claudio/.kube/config:ro \
-  -v ${HOME}/.config/gcloud:/home/claudio/.config/gcloud \
-  -v ${PWD}:/home/claudio/workdir \
-  -v ${HOME}/.docker/config.json:/home/claudio/.docker/config.json:ro \
-  -v ${HOME}/.gitconfig:/home/claudio/.gitconfig:ro \
-  -v ${HOME}/.ssh:/home/claudio/.ssh:ro \
-  -v ${SSH_AUTH_SOCK}:/tmp/ssh-agent.sock \
-  -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock \
-  -e GITLAB_TOKEN="${GITLAB_TOKEN}" \
-  -e ANTHROPIC_VERTEX_PROJECT_ID="${ANTHROPIC_VERTEX_PROJECT_ID}" \
-  -e ANTHROPIC_VERTEX_PROJECT_QUOTA="${ANTHROPIC_VERTEX_PROJECT_QUOTA}" \
-  -e SLACK_XOXC_TOKEN="${SLACK_XOXC_TOKEN}" \
-  -e SLACK_XOXD_TOKEN="${SLACK_XOXD_TOKEN}" \
-  quay.io/aipcc-cicd/claudio:v0.6.3 --allowedTools "Write(*)" "Glob(*)" "Read(*)" "$@"
+cp cli/claudio ~/.local/bin/claudio
+chmod +x ~/.local/bin/claudio
 ```
 
 The gcloud mount shares your host's Google Cloud credentials with the container. This is required because claudio uses Google Vertex AI as its default Claude API provider — `ANTHROPIC_VERTEX_PROJECT_ID` and `ANTHROPIC_VERTEX_PROJECT_QUOTA` identify the GCP project, while the gcloud credentials handle authentication. Make sure you're logged in on the host first (`gcloud auth application-default login`).

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ podman run -it --rm --userns=keep-id \
   -e ANTHROPIC_VERTEX_PROJECT_QUOTA="${ANTHROPIC_VERTEX_PROJECT_QUOTA}" \
   -e SLACK_XOXC_TOKEN="${SLACK_XOXC_TOKEN}" \
   -e SLACK_XOXD_TOKEN="${SLACK_XOXD_TOKEN}" \
-  quay.io/aipcc-cicd/claudio:v0.4.1 --allowedTools "Write(*)" "Glob(*)" "Read(*)" "$@"
+  quay.io/aipcc-cicd/claudio:v0.6.3 --allowedTools "Write(*)" "Glob(*)" "Read(*)" "$@"
 ```
 
 The gcloud mount shares your host's Google Cloud credentials with the container. This is required because claudio uses Google Vertex AI as its default Claude API provider — `ANTHROPIC_VERTEX_PROJECT_ID` and `ANTHROPIC_VERTEX_PROJECT_QUOTA` identify the GCP project, while the gcloud credentials handle authentication. Make sure you're logged in on the host first (`gcloud auth application-default login`).

--- a/cli/claudio
+++ b/cli/claudio
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Wrapper script to invoke the claudio container image with podman.
+
+set -euo pipefail
+
+# Load environment variables from ~/.config/claudio/.env if it exists
+ENV_FILE="${HOME}/.config/claudio/.env"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+podman run -it --rm --userns=keep-id \
+  -v ${HOME}/.kube/claudio-reader.kubeconfig:/home/claudio/.kube/config:ro \
+  -v ${HOME}/.config/gcloud:/home/claudio/.config/gcloud \
+  -v ${PWD}:/home/claudio/workdir \
+  -v ${HOME}/.docker/config.json:/home/claudio/.docker/config.json:ro \
+  -v ${HOME}/.gitconfig:/home/claudio/.gitconfig:ro \
+  -v ${HOME}/.ssh:/home/claudio/.ssh:ro \
+  -v ${SSH_AUTH_SOCK}:/tmp/ssh-agent.sock \
+  -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock \
+  -e GITLAB_TOKEN="${GITLAB_TOKEN}" \
+  -e ANTHROPIC_VERTEX_PROJECT_ID="${ANTHROPIC_VERTEX_PROJECT_ID}" \
+  -e ANTHROPIC_VERTEX_PROJECT_QUOTA="${ANTHROPIC_VERTEX_PROJECT_QUOTA}" \
+  -e SLACK_XOXC_TOKEN="${SLACK_XOXC_TOKEN}" \
+  -e SLACK_XOXD_TOKEN="${SLACK_XOXD_TOKEN}" \
+  quay.io/aipcc-cicd/claudio:v0.6.3 --allowedTools "Write(*)" "Glob(*)" "Read(*)" "$@"

--- a/cli/claudio
+++ b/cli/claudio
@@ -18,11 +18,11 @@ podman run -it --rm --userns=keep-id \
   -v ${HOME}/.docker/config.json:/home/claudio/.docker/config.json:ro \
   -v ${HOME}/.gitconfig:/home/claudio/.gitconfig:ro \
   -v ${HOME}/.ssh:/home/claudio/.ssh:ro \
-  -v ${SSH_AUTH_SOCK}:/tmp/ssh-agent.sock \
-  -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock \
-  -e GITLAB_TOKEN="${GITLAB_TOKEN}" \
-  -e ANTHROPIC_VERTEX_PROJECT_ID="${ANTHROPIC_VERTEX_PROJECT_ID}" \
-  -e ANTHROPIC_VERTEX_PROJECT_QUOTA="${ANTHROPIC_VERTEX_PROJECT_QUOTA}" \
-  -e SLACK_XOXC_TOKEN="${SLACK_XOXC_TOKEN}" \
-  -e SLACK_XOXD_TOKEN="${SLACK_XOXD_TOKEN}" \
+  ${SSH_AUTH_SOCK:+-v "${SSH_AUTH_SOCK}:/tmp/ssh-agent.sock"} \
+  ${SSH_AUTH_SOCK:+-e SSH_AUTH_SOCK=/tmp/ssh-agent.sock} \
+  ${GITLAB_TOKEN:+-e GITLAB_TOKEN="${GITLAB_TOKEN}"} \
+  ${ANTHROPIC_VERTEX_PROJECT_ID:+-e ANTHROPIC_VERTEX_PROJECT_ID="${ANTHROPIC_VERTEX_PROJECT_ID}"} \
+  ${ANTHROPIC_VERTEX_PROJECT_QUOTA:+-e ANTHROPIC_VERTEX_PROJECT_QUOTA="${ANTHROPIC_VERTEX_PROJECT_QUOTA}"} \
+  ${SLACK_XOXC_TOKEN:+-e SLACK_XOXC_TOKEN="${SLACK_XOXC_TOKEN}"} \
+  ${SLACK_XOXD_TOKEN:+-e SLACK_XOXD_TOKEN="${SLACK_XOXD_TOKEN}"} \
   quay.io/aipcc-cicd/claudio:v0.6.3 --allowedTools "Write(*)" "Glob(*)" "Read(*)" "$@"


### PR DESCRIPTION
Inlining the script in the README meant it could silently drift from reality. A standalone file is diffable across releases, easier to edit and manage, and provides users a single source to copy or symlink.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated CLI wrapper that streamlines running the tool, forwards user credentials/SSH agent, and mounts the current directory for seamless local workflow.

* **Documentation**
  * Setup instructions simplified: copy or symlink the CLI wrapper into ~/.local/bin and mark it executable.

* **Chores**
  * Container image tag bumped to v0.6.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aipcc-cicd/claudio/pull/140)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->