### PR TITLE
Log prompt before running entrypoint

### DIFF
--- a/integrations/gitlab-ci/claudio.yml
+++ b/integrations/gitlab-ci/claudio.yml
@@ -32,4 +32,5 @@
         exit 1
       fi
 
+      printf "=== PROMPT ===\n%s\n" "${CLAUDIO_PROMPT}"
       entrypoint.sh -p "${CLAUDIO_PROMPT}" ${CLAUDIO_EXTRA_ARGS}

--- a/integrations/gitlab-ci/template/claudio.yml
+++ b/integrations/gitlab-ci/template/claudio.yml
@@ -32,4 +32,5 @@
         exit 1
       fi
 
+      printf "=== PROMPT ===\n%s\n" "${CLAUDIO_PROMPT}"
       entrypoint.sh -p "${CLAUDIO_PROMPT}" ${CLAUDIO_EXTRA_ARGS}


### PR DESCRIPTION
Print the CLAUDIO_PROMPT in the script block so downstream jobs don't need to add their own before_script just to log it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitLab CI integration now displays the prompt configuration in job logs before execution, improving visibility into job parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aipcc-cicd/claudio/pull/142)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->