### PR TITLE
fix(build): fetch latest commit when building from branch

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -38,8 +38,9 @@ ARG CS_REF
 # cache so we always get fresh content when the remote ref updates.
 ARG CS_CACHE_KEY
 ENV CS_REPO https://github.com/aipcc-cicd/claudio-skills.git
-RUN set -eux; \
-    if [ "${CS_REF_TYPE}" = "pr" ]; then \ 
+RUN echo "cs-cache-key: ${CS_CACHE_KEY}" \
+ && set -eux; \
+    if [ "${CS_REF_TYPE}" = "pr" ]; then \
         git clone "${CS_REPO}"; \
         git -C claudio-skills fetch --depth 1 origin "pull/${CS_REF}/head"; \
         git -C claudio-skills checkout FETCH_HEAD; \
@@ -82,7 +83,11 @@ COPY scripts/ entrypoint.sh /usr/local/bin/
 COPY --from=preparer /claudio-skills /home/claudio/claudio-skills
 ARG CS_REF_TYPE
 ARG CS_REF
-RUN if [ "${CS_REF_TYPE}" != "pr" ]; then \
+ARG CS_CACHE_KEY
+RUN echo "cs-cache-key: ${CS_CACHE_KEY}" \
+ && if [ "${CS_REF_TYPE}" = "branch" ]; then \
+        claude plugin marketplace add aipcc-cicd/claudio-skills#${CS_REF}; \
+    elif [ "${CS_REF_TYPE}" != "pr" ]; then \
         claude plugin marketplace add aipcc-cicd/claudio-skills@v${CS_REF}; \
     else \
          claude plugin marketplace add /home/claudio/claudio-skills; \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ARTIFACT_NAME ?= claudio
 
 # Claudio skills
 #
-# CS_REF_TYPE can be tag or pr
+# CS_REF_TYPE can be branch, tag, or pr
 # Example when we create a tag version for claudio
 CS_REF_TYPE  ?= tag
 CS_REF  ?= 0.5.3


### PR DESCRIPTION
README documents that build from branch is supported but it was not handled in Containerfile. Use commit digest so that cache is not used when new commit is pushed to branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized container build caching strategy for improved build efficiency
  * Extended build configuration options to support branch references in addition to existing tag and pull request support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aipcc-cicd/claudio/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->