### PR TITLE
feat: add PreToolUse hook to auto-allow plugin script commands

### DIFF
--- a/conf/.claude/hooks/smart-permissions.sh
+++ b/conf/.claude/hooks/smart-permissions.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -z "$COMMAND" ] && exit 0
+
+INSTALLED="${HOME}/.claude/plugins/installed_plugins.json"
+[ -f "$INSTALLED" ] || exit 0
+
+mapfile -t PLUGIN_PATHS < <(jq -r '.plugins[] | .[].installPath' "$INSTALLED" 2>/dev/null)
+[ ${#PLUGIN_PATHS[@]} -eq 0 ] && exit 0
+
+# Extract the executable: strip leading bash/sh/python wrapper if present
+EXECUTABLE=$(echo "$COMMAND" | awk '{
+    if ($1 ~ /^(bash|sh|python[0-9.]*)$/) print $2; else print $1
+}')
+
+# Resolve to absolute path
+EXECUTABLE=$(realpath -q "$EXECUTABLE" 2>/dev/null || echo "$EXECUTABLE")
+
+for plugin_path in "${PLUGIN_PATHS[@]}"; do
+    case "$EXECUTABLE" in
+        "${plugin_path}"/*)
+            jq -n '{
+                hookSpecificOutput: {
+                    hookEventName: "PreToolUse",
+                    permissionDecision: "allow",
+                    permissionDecisionReason: "Command executes a plugin script"
+                }
+            }'
+            exit 0
+            ;;
+    esac
+done
+
+exit 0

--- a/scripts/pt-manager.sh
+++ b/scripts/pt-manager.sh
@@ -26,6 +26,19 @@ if [ ${#new_perms[@]} -gt 0 ]; then
     mv "$tmp" "$settings"
 fi
 
+# Register PreToolUse hook to auto-allow commands that invoke plugin scripts.
+# Workaround for broken permission matching in Claude Code:
+# https://github.com/anthropics/claude-code/issues/14956
+# https://github.com/anthropics/claude-code/issues/30519
+echo "Registering PreToolUse hook for plugin script permissions..." >&2
+hook_script="${HOME}/.claude/hooks/smart-permissions.sh"
+if [ -f "$hook_script" ]; then
+    tmp=$(mktemp)
+    jq --arg cmd "bash ${hook_script}" '.hooks.PreToolUse = ((.hooks.PreToolUse // []) + [{"matcher": "Bash", "hooks": [{"type": "command", "command": $cmd}]}])' \
+        "$settings" > "$tmp"
+    mv "$tmp" "$settings"
+fi
+
 echo "Running installation scripts for installed plugins..." >&2
 while IFS= read -r location; do
     while IFS= read -r script; do


### PR DESCRIPTION
Workaround for broken permission matching in Claude Code (#14956, #30519). The hook reads installed_plugins.json at runtime and auto-allows Bash commands that invoke scripts shipped by installed plugins.

Related to https://github.com/aipcc-cicd/claudio-skills/pull/59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated permission verification system for plugin script execution to enhance security when running plugins.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aipcc-cicd/claudio/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->