### PR TITLE
fix: point renovate claudio-skills manager at Makefile CS_REF

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,15 +35,15 @@
       "customType": "regex",
       "description": "Update Claudio Skills version",
       "managerFilePatterns": [
-        "Containerfile"
+        "Makefile"
       ],
       "matchStrings": [
-        "ENV\\s+CLAUDIO_SKILLS_V\\s+v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "CS_REF\\s+\\?=\\s+(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "aipcc-cicd/claudio-skills",
       "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+)$",
-      "autoReplaceStringTemplate": "ENV CLAUDIO_SKILLS_V v{{newVersion}}"
+      "autoReplaceStringTemplate": "CS_REF  ?= {{newValue}}"
     }
   ],
   "packageRules": []


### PR DESCRIPTION
The regex was matching ENV CLAUDIO_SKILLS_V in Containerfile which doesn't exist. The actual version is CS_REF in the Makefile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated version management configuration to improve dependency tracking and updates across build files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aipcc-cicd/claudio/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->