### PR TITLE
fix: extract verdict from evaluation model output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,15 +11,14 @@ fi
 ADC_PATH="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
 CLAUDIO_RESULT_FILE="${CLAUDIO_RESULT_FILE:-}"
 CLAUDIO_EVALUATION_PROMPT="${CLAUDIO_EVALUATION_PROMPT:-$(cat <<'EOF'
-Read this Claude Code session log.
+Read this Claude Code session log and determine whether the task completed successfully.
 
-Determine whether the original task was FULLY completed successfully.
+Your entire response must be a single word or line — no preamble, no explanation:
 
-Return ONLY one of:
-- SUCCESS
-- FAILURE: <short reason>
+SUCCESS
+FAILURE: <short reason>
 
-Mark the task as FAILURE if:
+Rules for FAILURE:
 - the agent abandoned the task
 - commands or tool calls failed without recovery
 - tests failed
@@ -185,15 +184,22 @@ if [ "$claude_rc" -ne 0 ] && [ "$claude_rc" -ne 143 ]; then exit "$claude_rc"; f
 if [ -n "${CLAUDIO_RESULT_FILE}" ] && [ -s "${CLAUDIO_LOG_FILE:-}" ]; then
   echo "=== Evaluating task result ==="
 
-  if ! tail -c "${CLAUDIO_RESULT_MAX_CHARS:-50000}" "${CLAUDIO_LOG_FILE}" | \
+  eval_output=""
+  if ! eval_output=$(tail -c "${CLAUDIO_RESULT_MAX_CHARS:-50000}" "${CLAUDIO_LOG_FILE}" | \
     claude -p "${CLAUDIO_EVALUATION_PROMPT}" \
       --model "${CLAUDIO_EVALUATION_MODEL:-claude-haiku-4-5-20251001}" \
-      --no-session-persistence \
-      > "${CLAUDIO_RESULT_FILE}"
+      --no-session-persistence)
   then
     echo "ERROR: Failed to evaluate task result"
     exit 1
   fi
+
+  # Extract the verdict line — models sometimes wrap it in extra text
+  verdict=$(echo "$eval_output" | grep -oE '^(SUCCESS|FAILURE: .+)' | head -n1)
+  if [ -z "$verdict" ]; then
+    verdict=$(echo "$eval_output" | grep -oE '(SUCCESS|FAILURE: .+)' | head -n1)
+  fi
+  echo "${verdict:-$eval_output}" > "${CLAUDIO_RESULT_FILE}"
 
   validate_result
   exit $?

--- a/scripts/stream-claude.py
+++ b/scripts/stream-claude.py
@@ -264,12 +264,12 @@ while True:
         block = event.get("content_block", {})
         block_type = block.get("type")
         if block_type == "text":
-            print(f"{CLAUDE_COLOR}\U0001f4ac Claude ", end="", flush=True)
-            _log("\U0001f4ac Claude ")
+            print(f"{CLAUDE_COLOR}\U0001f4ac Claude: ", end="", flush=True)
+            _log("\U0001f4ac Claude: ")
             active_block = "text"
         elif block_type == "thinking":
-            print(f"{THINK_COLOR}\U0001f9e0 Thinking ", end="", flush=True)
-            _log("\U0001f9e0 Thinking ")
+            print(f"{THINK_COLOR}\U0001f9e0 Thinking: ", end="", flush=True)
+            _log("\U0001f9e0 Thinking: ")
             active_block = "thinking"
         elif block_type in ("tool_use", "server_tool_use"):
             tool_name = block.get("name", "unknown")


### PR DESCRIPTION
## Summary

The evaluation model (`claude-haiku-4-5`) sometimes wraps its `SUCCESS`/`FAILURE` verdict in extra text (e.g., `Based on the session log analysis, the task was **FULLY completed successfully**...`), causing `validate_result` to reject the response as invalid format — even when the task fully succeeded.

Two fixes:
- **Tighten the evaluation prompt** — "entire response must be a single word or line" instead of "return ONLY one of", which haiku sometimes ignores
- **Extract the verdict with grep** — instead of piping the full model output to the result file, extract the `SUCCESS` or `FAILURE: ...` line as a fallback when the model is still verbose

Falls back to the raw output if no verdict pattern is found, preserving the existing error reporting.

Example failure from CI: https://gitlab.com/redhat/rhel-ai/ci-cd/aipcc-product-management-configs/-/jobs/14538586291

## Test plan

- [ ] Verify with a verbose model response containing `SUCCESS` mid-text
- [ ] Verify clean `SUCCESS` / `FAILURE: reason` still works as before
- [ ] Verify fallback when no verdict pattern is found (raw output written, validation fails as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Jakub Rusz <jrusz@redhat.com>