### PR TITLE
fix(release): pin skills version in Makefile for traceability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,6 @@ on:
         description: 'Release version (e.g. v0.8.0)'
         required: true
         type: string
-      skills_ref:
-        description: 'claudio-skills tag to pin (e.g. v0.5.5)'
-        required: true
-        type: string
 
 permissions: {}
 
@@ -35,14 +31,9 @@ jobs:
     - name: Validate inputs
       env:
         INPUT_VERSION: ${{ inputs.version }}
-        INPUT_SKILLS_REF: ${{ inputs.skills_ref }}
       run: |
         if [[ ! "${INPUT_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
           echo "::error::Invalid version '${INPUT_VERSION}'. Expected format: v0.8.0 or v0.8.0-rc1"
-          exit 1
-        fi
-        if [[ ! "${INPUT_SKILLS_REF}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-          echo "::error::Invalid skills_ref '${INPUT_SKILLS_REF}'. Expected format: v0.5.5 or v0.5.5-rc1"
           exit 1
         fi
 
@@ -79,8 +70,6 @@ jobs:
     - name: Build image (${{ matrix.arch }})
       env:
         VERSION: ${{ inputs.version }}
-        CS_REF_TYPE: tag
-        CS_REF: ${{ inputs.skills_ref }}
         IMAGE_REPO: ${{ env.QUAY_IMAGE_REPO }}
         IMAGE_TAG: ${{ inputs.version }}
         IMAGE_NAME: ${{ env.QUAY_IMAGE_REPO }}:${{ inputs.version }}-${{ matrix.arch }}

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ IMAGE_SOURCE_TAG ?= $(IMAGE_TAG)
 ARTIFACT_NAME ?= claudio
 
 # Claudio skills — ref type (branch, tag, or pr) and ref value.
-# Override via env vars for release builds: CS_REF_TYPE=tag CS_REF=v0.5.5
-CS_REF_TYPE  ?= branch
-CS_REF  ?= main
+# Override for development: CS_REF_TYPE=branch CS_REF=main
+CS_REF_TYPE  ?= tag
+CS_REF  ?= v0.6.2
 CS_REPO ?= https://github.com/aipcc-cicd/claudio-skills.git
 # Resolve the remote HEAD SHA for the skills ref so the build cache
 # invalidates automatically when the PR/branch gets new commits.

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,15 @@
       "datasourceTemplate": "docker",
       "depNameTemplate": "google/cloud-sdk",
       "autoReplaceStringTemplate": "ENV GCLOUD_V {{newVersion}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Claudio Skills version",
+      "managerFilePatterns": ["Makefile"],
+      "matchStrings": ["CS_REF\\s+\\?=\\s+(?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "aipcc-cicd/claudio-skills",
+      "autoReplaceStringTemplate": "CS_REF  ?= {{newValue}}"
     }
   ],
   "packageRules": []


### PR DESCRIPTION
## Summary

- Pin `CS_REF` to a specific skills tag (`v0.6.2`) in the Makefile instead of defaulting to `main`
- Add Renovate custom manager to auto-bump the skills version on new releases
- Remove `skills_ref` workflow input from the release workflow — builds use Makefile defaults

## Problem

Three issues with the current release workflow (reported by @ppitonak):

1. **Same commit**: v0.7.1, v0.7.2, v0.7.3 all tag commit f7420fc — multiple releases are indistinguishable in git history
2. **Invisible skills_ref**: `skills_ref` is a workflow input never recorded in git — you must inspect the container image to find which skills version a release uses
3. **Broken changelog**: `--generate-notes` always diffs against v0.6.1 because all v0.7.x tags target the same commit

## Solution

Make the skills version a tracked dependency — pin it in the Makefile, let Renovate bump it. Each Renovate PR creates a new commit, so releases naturally get distinct SHAs and meaningful changelogs.

The `?=` pattern preserves local override for development: `CS_REF_TYPE=branch CS_REF=main make oci-build`.

## Test plan

- [x] YAML and JSON syntax validation
- [x] `git ls-remote` resolves pinned tag to correct SHA
- [ ] CI builds PR image using pinned skills version
- [ ] After merge: trigger a test release (e.g. `v0.8.0-rc1`) with only the `version` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration defaults for dependencies.
  * Enhanced workflow automation for dependency version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->