### PR TITLE
AIPCC-15315: Remove pyopenssl CVE-2026-27459 workaround

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -93,10 +93,6 @@ RUN echo "cs-cache-key: ${CS_CACHE_KEY}" \
     claude plugin install --scope user claudio-plugin; \
     pt-manager.sh
 
-# pyopenssl is pulled in transitively by the UBI10 base image and is not a direct
-# dependency. CVE-2026-27459 (CRITICAL) affects <26.0.0; pin the fixed version.
-RUN pip install --no-cache-dir "pyopenssl>=26.0.0"
-
 # Claudio
 RUN chown -R claudio:0 ${HOME}; \
     chmod -R ug+rwx ${HOME}


### PR DESCRIPTION
## Summary
- Removes the `pip install --no-cache-dir "pyopenssl>=26.0.0"` workaround introduced in PR #136 (AIPCC-15313)
- Investigation showed that pyopenssl is **not** a transitive dependency of the UBI10 base image, `microdnf`-installed RPMs, skills requirements, or Google Cloud SDK — the workaround was the only thing introducing it into the image
- Removing it eliminates the package entirely, which resolves CVE-2026-27459 without needing a base image bump

## Investigation details
Checked all possible sources of pyopenssl in the built image:

| Source | pyopenssl present? |
|---|---|
| UBI10 `python-312-minimal` base image | No |
| `microdnf install` RPMs (skopeo, podman, git, etc.) | No |
| claudio-skills `requirements.txt` | No |
| Inline `# /// script` dependencies | None exist |
| Google Cloud SDK bundle | No (only urllib3 contrib shims) |
| The workaround itself | **Yes** — sole installer |

`pip show pyopenssl` on the built `claudio:v0.7.3` image confirms `Required-by:` is empty — nothing depends on it.

## Test plan
- [ ] CI image build passes without the workaround
- [ ] Rebuilt image does NOT contain pyopenssl (`pip show pyopenssl` returns nothing)
- [ ] Platform scanner (GITL-005) no longer reports CVE-2026-27459

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a pinned dependency version from container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->