### PR TITLE
feat: add opt-in Tekton result output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,16 @@ name: Build
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'integrations/**'
+      - 'blog/**'
+      - 'README.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'integrations/**'
+      - 'blog/**'
+      - 'README.md'
 
 env:
   # GHCR configuration

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Default DEBUG to false if not set
 DEBUG="${DEBUG:-false}"
@@ -92,8 +93,8 @@ if ! check_adc; then
   echo "Running gcloud auth application-default login..."
   gcloud auth application-default login --quiet
   # Setup project and quota
-  gcloud config set project ${ANTHROPIC_VERTEX_PROJECT_ID}
-  gcloud auth application-default set-quota-project ${ANTHROPIC_VERTEX_PROJECT_QUOTA}
+  gcloud config set project "${ANTHROPIC_VERTEX_PROJECT_ID:-}"
+  gcloud auth application-default set-quota-project "${ANTHROPIC_VERTEX_PROJECT_QUOTA:-}"
 fi
 
 # Configure git identity (defaults can be overridden via env vars)
@@ -123,6 +124,10 @@ CLAUDE_MD="${HOME}/.claude/CLAUDE.md"
 for c in ~/.claude/context.d/*.md; do
   [ -f "$c" ] && echo "@$c" >>"$CLAUDE_MD"
 done
+
+if [ -n "${CLAUDIO_PROMPT:-}" ] && [ "${CLAUDIO_LOG_PROMPT:-1}" = "1" ]; then
+  printf "=== PROMPT ===\n%s\n" "${CLAUDIO_PROMPT}"
+fi
 
 # --- Non-streaming mode: transparent passthrough ---
 if [ "${CLAUDIO_STREAM:-}" != "1" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ fi
 
 ADC_PATH="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
 CLAUDIO_RESULT_FILE="${CLAUDIO_RESULT_FILE:-}"
+CLAUDIO_VALIDATE_RESULT="${CLAUDIO_VALIDATE_RESULT:-true}"
 CLAUDIO_EVALUATION_PROMPT="${CLAUDIO_EVALUATION_PROMPT:-$(cat <<'EOF'
 Read this Claude Code session log and determine whether the task completed successfully.
 
@@ -199,15 +200,19 @@ if [ -n "${CLAUDIO_RESULT_FILE}" ] && [ -s "${CLAUDIO_LOG_FILE:-}" ]; then
     exit 1
   fi
 
-  # Extract the verdict line — models sometimes wrap it in extra text
-  verdict=$(echo "$eval_output" | grep -oE '^(SUCCESS|FAILURE: .+)' | head -n1)
-  if [ -z "$verdict" ]; then
-    verdict=$(echo "$eval_output" | grep -oE '(SUCCESS|FAILURE: .+)' | head -n1)
-  fi
-  echo "${verdict:-$eval_output}" > "${CLAUDIO_RESULT_FILE}"
+  if [[ "$CLAUDIO_VALIDATE_RESULT" == "true" ]]; then
+    # Extract the verdict line — models sometimes wrap it in extra text
+    verdict=$(echo "$eval_output" | grep -oE '^(SUCCESS|FAILURE: .+)' | head -n1)
+    if [ -z "$verdict" ]; then
+      verdict=$(echo "$eval_output" | grep -oE '(SUCCESS|FAILURE: .+)' | head -n1)
+    fi
+    echo "${verdict:-$eval_output}" > "${CLAUDIO_RESULT_FILE}"
 
-  validate_result
-  exit $?
+    validate_result
+    exit $?
+  else
+    echo "$eval_output" > "${CLAUDIO_RESULT_FILE}"
+  fi
 fi
 
 exit 0

--- a/integrations/gitlab-ci/claudio.yml
+++ b/integrations/gitlab-ci/claudio.yml
@@ -14,23 +14,17 @@
 #       CLAUDIO_PROMPT: "Analyze the latest MRs and report to Slack"
 #
 # Optional variables to override:
-#   CLAUDIO_IMAGE       - claudio container image (default: quay.io/aipcc-cicd/claudio:latest)
 #   CLAUDIO_EXTRA_ARGS  - Extra arguments passed to claudio
 #
 
 .claudio:
   image:
-    name: ${CLAUDIO_IMAGE}
+    name: quay.io/aipcc-cicd/claudio:v0.7.3
     entrypoint: [""]
   variables:
-    CLAUDIO_IMAGE: "quay.io/aipcc-cicd/claudio:latest"
     CLAUDIO_EXTRA_ARGS: ""
   script:
     - |
-      if [ -z "${CLAUDIO_PROMPT}" ]; then
-        echo "ERROR: CLAUDIO_PROMPT variable is not set" >&2
-        exit 1
-      fi
-
-      printf "=== PROMPT ===\n%s\n" "${CLAUDIO_PROMPT}"
+      #!/usr/bin/env bash
+      set -euo pipefail
       entrypoint.sh -p "${CLAUDIO_PROMPT}" ${CLAUDIO_EXTRA_ARGS}

--- a/integrations/tekton/claudio.yml
+++ b/integrations/tekton/claudio.yml
@@ -95,6 +95,11 @@ spec:
       default: ""
       description: Disable ANSI colors ("1")
 
+    - name: output-result
+      type: string
+      default: "false"
+      description: Write evaluation output to the Tekton result ("true" to enable)
+
     # Credentials
     - name: gcp-credentials
       type: string
@@ -117,6 +122,13 @@ spec:
       type: array
       default: []
       description: List of Kubernetes Secrets to load as env vars
+
+  results:
+    - name: output
+      description: >
+        Populated when output-result is "true". Uses the evaluation prompt
+        to summarize the session (default: SUCCESS/FAILURE verdict;
+        override CLAUDIO_EVALUATION_PROMPT for custom output like summaries).
 
   workspaces:
     - name: source
@@ -162,6 +174,9 @@ spec:
         - name: NO_COLOR
           value: $(params.no-color)
 
+        - name: CLAUDIO_OUTPUT_RESULT
+          value: $(params.output-result)
+
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/gcp/application_default_credentials.json
 
@@ -171,6 +186,12 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
+
+        touch "$(results.output.path)"
+
+        if [[ "$CLAUDIO_OUTPUT_RESULT" == "true" ]]; then
+          export CLAUDIO_RESULT_FILE="$(results.output.path)"
+        fi
 
         if [[ "$(workspaces.source.bound)" == "true" ]]; then
           cd "$(workspaces.source.path)"
@@ -212,6 +233,6 @@ spec:
           done
         fi
 
-        exec entrypoint.sh \
+        entrypoint.sh \
           -p "$CLAUDIO_PROMPT" \
           "$@"

--- a/integrations/tekton/claudio.yml
+++ b/integrations/tekton/claudio.yml
@@ -1,0 +1,217 @@
+# Reusable Tekton Task for running Claudio jobs.
+#
+# Prerequisites:
+#
+# 1. Create the GCP credentials Secret (see gcp-credentials param description)
+#
+# 2. Apply this Task to your cluster:
+#
+#      kubectl apply -f integrations/tekton/claudio.yml
+#
+# Usage:
+#
+#   apiVersion: tekton.dev/v1
+#   kind: TaskRun
+#   metadata:
+#     name: my-claudio-run
+#   spec:
+#     taskRef:
+#       name: claudio
+#     params:
+#       - name: prompt
+#         value: "Summarize the latest release notes"
+#
+# For repository-based tasks, bind the source workspace:
+#
+#   workspaces:
+#     - name: source
+#       persistentVolumeClaim:
+#         claimName: my-source-pvc
+#
+# Secret injection:
+#
+# The Task accepts an env-secrets array param. At runtime, each Secret
+# is read via kubectl and its keys are exported as environment variables.
+#
+# If you use env-secrets, the service account must be able to read them.
+# Use --resource-name to limit access to only the secrets the task needs:
+#
+#      kubectl create role claudio-env-secrets \
+#        --verb=get --resource=secrets \
+#        --resource-name=gitlab-credentials \
+#        --resource-name=slack-bot-token
+#      kubectl create rolebinding claudio-env-secrets \
+#        --role=claudio-env-secrets \
+#        --serviceaccount=<NAMESPACE>:<SERVICE_ACCOUNT>
+#
+# Example:
+#
+#   params:
+#     - name: env-secrets
+#       value:
+#         - gitlab-credentials
+#         - slack-bot-token
+#
+
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: claudio
+
+spec:
+  params:
+    # Claudio
+    - name: prompt
+      type: string
+      description: Prompt/task for Claudio (required)
+
+    - name: extra-args
+      type: array
+      default: []
+      description: Extra arguments passed to Claudio
+
+    - name: stream
+      type: string
+      default: "1"
+      description: Enable streaming mode
+
+    - name: log-file
+      type: string
+      default: ""
+      description: Path for plain-text logs (streaming only)
+
+    - name: wrap
+      type: string
+      default: ""
+      description: Word wrap at N columns (streaming only)
+
+    - name: result-file
+      type: string
+      default: ""
+      description: File to write SUCCESS/FAILURE evaluation
+
+    - name: no-color
+      type: string
+      default: ""
+      description: Disable ANSI colors ("1")
+
+    # Credentials
+    - name: gcp-credentials
+      type: string
+      default: "claudio-adc"
+      description: |
+        Secret holding the GCP Vertex AI credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: claudio-adc
+        type: Opaque
+        data:
+          application_default_credentials.json: ${adc_json}
+          ANTHROPIC_VERTEX_PROJECT_ID: ${project_id}
+          ANTHROPIC_VERTEX_PROJECT_QUOTA: ${quota_project}
+
+    - name: env-secrets
+      type: array
+      default: []
+      description: List of Kubernetes Secrets to load as env vars
+
+  workspaces:
+    - name: source
+      optional: true
+
+  volumes:
+    - name: gcp-credentials
+      secret:
+        secretName: $(params.gcp-credentials)
+
+  steps:
+    - name: run
+      image: quay.io/aipcc-cicd/claudio:v0.7.3
+
+      args:
+        - $(params.extra-args[*])
+
+      volumeMounts:
+        - name: gcp-credentials
+          mountPath: /var/run/secrets/gcp
+          readOnly: true
+
+      envFrom:
+        - secretRef:
+            name: $(params.gcp-credentials)
+
+      env:
+        - name: CLAUDIO_PROMPT
+          value: $(params.prompt)
+
+        - name: CLAUDIO_STREAM
+          value: $(params.stream)
+
+        - name: CLAUDIO_LOG_FILE
+          value: $(params.log-file)
+
+        - name: CLAUDIO_WRAP
+          value: $(params.wrap)
+
+        - name: CLAUDIO_RESULT_FILE
+          value: $(params.result-file)
+
+        - name: NO_COLOR
+          value: $(params.no-color)
+
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/gcp/application_default_credentials.json
+
+        - name: ENV_SECRETS
+          value: "$(params.env-secrets[*])"
+
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ "$(workspaces.source.bound)" == "true" ]]; then
+          cd "$(workspaces.source.path)"
+        fi
+
+        load_secret() {
+          local secret_name="$1"
+          local key value tmpfile
+
+          echo "Loading secret: ${secret_name}"
+
+          tmpfile=$(mktemp)
+          trap "rm -f '$tmpfile'" RETURN
+
+          kubectl get secret "${secret_name}" \
+            -o go-template='{{range $k,$v := .data}}{{printf "%s\x00%s\x00" $k ($v|base64decode)}}{{end}}' \
+            > "$tmpfile" || {
+            echo "ERROR: failed loading ${secret_name}" >&2
+            exit 1
+          }
+
+          while IFS= read -r -d '' key && IFS= read -r -d '' value; do
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+            export "$key=$value"
+          done < "$tmpfile"
+        }
+
+        read -ra secrets <<< "$ENV_SECRETS"
+
+        if [[ ${#secrets[@]} -gt 0 && -n "${secrets[0]}" ]]; then
+          command -v kubectl >/dev/null || {
+            echo "ERROR: kubectl not found but ENV_SECRETS requires it"
+            exit 1
+          }
+
+          for secret in "${secrets[@]}"; do
+            [[ -n "$secret" ]] || continue
+            load_secret "$secret"
+          done
+        fi
+
+        exec entrypoint.sh \
+          -p "$CLAUDIO_PROMPT" \
+          "$@"


### PR DESCRIPTION
## Summary
- Add output-result param to the Tekton task that wires CLAUDIO_RESULT_FILE to the Tekton result path when true
- Add CLAUDIO_VALIDATE_RESULT env var to entrypoint (default true) — when false, skips SUCCESS/FAILURE verdict extraction and writes raw evaluation output
- Enables downstream Tekton tasks (e.g. slack-webhook-notification) to consume Claudio evaluation output via $(tasks.claudio.results.output)

## Test plan
- [ ] Run with output-result false (default) — result should be empty, no evaluation triggered via this path
- [ ] Run with output-result true and default evaluation prompt — result should contain SUCCESS/FAILURE verdict
- [ ] Run with output-result true and custom CLAUDIO_EVALUATION_PROMPT + CLAUDIO_VALIDATE_RESULT=false — result should contain raw evaluation output