### PR TITLE
feat: add opt-in Tekton result output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,25 @@ if [ "$DEBUG" = "true" ]; then
 fi
 
 ADC_PATH="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
+CLAUDIO_RESULT_FILE="${CLAUDIO_RESULT_FILE:-}"
+CLAUDIO_VALIDATE_RESULT="${CLAUDIO_VALIDATE_RESULT:-true}"
+CLAUDIO_EVALUATION_PROMPT="${CLAUDIO_EVALUATION_PROMPT:-$(cat <<'EOF'
+Read this Claude Code session log and determine whether the task completed successfully.
+
+Your entire response must be a single word or line — no preamble, no explanation:
+
+SUCCESS
+FAILURE: <short reason>
+
+Rules for FAILURE:
+- the agent abandoned the task
+- commands or tool calls failed without recovery
+- tests failed
+- the requested work was only partially completed
+- the final state is uncertain
+- the task could not be verified as complete
+EOF
+)}"
 
 ###################
 #### Functions ####
@@ -110,5 +129,36 @@ wait "$claude_pid" 2>/dev/null && claude_rc=0 || claude_rc=$?
 
 # 143 = SIGTERM (expected when we kill claude after stream ends)
 if [ "$stream_rc" -ne 0 ]; then exit "$stream_rc"; fi
-if [ "$claude_rc" -eq 0 ] || [ "$claude_rc" -eq 143 ]; then exit 0; fi
-exit "$claude_rc"
+if [ "$claude_rc" -ne 0 ] && [ "$claude_rc" -ne 143 ]; then exit "$claude_rc"; fi
+
+# Result check: use a second Claude call to evaluate whether the task
+# actually completed successfully based on the session log.
+if [ -n "${CLAUDIO_RESULT_FILE}" ] && [ -s "${CLAUDIO_LOG_FILE:-}" ]; then
+  echo "=== Evaluating task result ==="
+
+  eval_output=""
+  if ! eval_output=$(tail -c "${CLAUDIO_RESULT_MAX_CHARS:-50000}" "${CLAUDIO_LOG_FILE}" | \
+    claude -p "${CLAUDIO_EVALUATION_PROMPT}" \
+      --model "${CLAUDIO_EVALUATION_MODEL:-claude-haiku-4-5-20251001}" \
+      --no-session-persistence)
+  then
+    echo "ERROR: Failed to evaluate task result"
+    exit 1
+  fi
+
+  if [[ "$CLAUDIO_VALIDATE_RESULT" == "true" ]]; then
+    # Extract the verdict line — models sometimes wrap it in extra text
+    verdict=$(echo "$eval_output" | grep -oE '^(SUCCESS|FAILURE: .+)' | head -n1)
+    if [ -z "$verdict" ]; then
+      verdict=$(echo "$eval_output" | grep -oE '(SUCCESS|FAILURE: .+)' | head -n1)
+    fi
+    echo "${verdict:-$eval_output}" > "${CLAUDIO_RESULT_FILE}"
+
+    validate_result
+    exit $?
+  else
+    echo "$eval_output" > "${CLAUDIO_RESULT_FILE}"
+  fi
+fi
+
+exit 0

--- a/integrations/tekton/claudio.yml
+++ b/integrations/tekton/claudio.yml
@@ -1,0 +1,238 @@
+# Reusable Tekton Task for running Claudio jobs.
+#
+# Prerequisites:
+#
+# 1. Create the GCP credentials Secret (see gcp-credentials param description)
+#
+# 2. Apply this Task to your cluster:
+#
+#      kubectl apply -f integrations/tekton/claudio.yml
+#
+# Usage:
+#
+#   apiVersion: tekton.dev/v1
+#   kind: TaskRun
+#   metadata:
+#     name: my-claudio-run
+#   spec:
+#     taskRef:
+#       name: claudio
+#     params:
+#       - name: prompt
+#         value: "Summarize the latest release notes"
+#
+# For repository-based tasks, bind the source workspace:
+#
+#   workspaces:
+#     - name: source
+#       persistentVolumeClaim:
+#         claimName: my-source-pvc
+#
+# Secret injection:
+#
+# The Task accepts an env-secrets array param. At runtime, each Secret
+# is read via kubectl and its keys are exported as environment variables.
+#
+# If you use env-secrets, the service account must be able to read them.
+# Use --resource-name to limit access to only the secrets the task needs:
+#
+#      kubectl create role claudio-env-secrets \
+#        --verb=get --resource=secrets \
+#        --resource-name=gitlab-credentials \
+#        --resource-name=slack-bot-token
+#      kubectl create rolebinding claudio-env-secrets \
+#        --role=claudio-env-secrets \
+#        --serviceaccount=<NAMESPACE>:<SERVICE_ACCOUNT>
+#
+# Example:
+#
+#   params:
+#     - name: env-secrets
+#       value:
+#         - gitlab-credentials
+#         - slack-bot-token
+#
+
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: claudio
+
+spec:
+  params:
+    # Claudio
+    - name: prompt
+      type: string
+      description: Prompt/task for Claudio (required)
+
+    - name: extra-args
+      type: array
+      default: []
+      description: Extra arguments passed to Claudio
+
+    - name: stream
+      type: string
+      default: "1"
+      description: Enable streaming mode
+
+    - name: log-file
+      type: string
+      default: ""
+      description: Path for plain-text logs (streaming only)
+
+    - name: wrap
+      type: string
+      default: ""
+      description: Word wrap at N columns (streaming only)
+
+    - name: result-file
+      type: string
+      default: ""
+      description: File to write SUCCESS/FAILURE evaluation
+
+    - name: no-color
+      type: string
+      default: ""
+      description: Disable ANSI colors ("1")
+
+    - name: output-result
+      type: string
+      default: "false"
+      description: Write evaluation output to the Tekton result ("true" to enable)
+
+    # Credentials
+    - name: gcp-credentials
+      type: string
+      default: "claudio-adc"
+      description: |
+        Secret holding the GCP Vertex AI credentials. Secret should be accessible to this task.
+
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: claudio-adc
+        type: Opaque
+        data:
+          application_default_credentials.json: ${adc_json}
+          ANTHROPIC_VERTEX_PROJECT_ID: ${project_id}
+          ANTHROPIC_VERTEX_PROJECT_QUOTA: ${quota_project}
+
+    - name: env-secrets
+      type: array
+      default: []
+      description: List of Kubernetes Secrets to load as env vars
+
+  results:
+    - name: output
+      description: >
+        Populated when output-result is "true". Uses the evaluation prompt
+        to summarize the session (default: SUCCESS/FAILURE verdict;
+        override CLAUDIO_EVALUATION_PROMPT for custom output like summaries).
+
+  workspaces:
+    - name: source
+      optional: true
+
+  volumes:
+    - name: gcp-credentials
+      secret:
+        secretName: $(params.gcp-credentials)
+
+  steps:
+    - name: run
+      image: quay.io/aipcc-cicd/claudio:v0.7.3
+
+      args:
+        - $(params.extra-args[*])
+
+      volumeMounts:
+        - name: gcp-credentials
+          mountPath: /var/run/secrets/gcp
+          readOnly: true
+
+      envFrom:
+        - secretRef:
+            name: $(params.gcp-credentials)
+
+      env:
+        - name: CLAUDIO_PROMPT
+          value: $(params.prompt)
+
+        - name: CLAUDIO_STREAM
+          value: $(params.stream)
+
+        - name: CLAUDIO_LOG_FILE
+          value: $(params.log-file)
+
+        - name: CLAUDIO_WRAP
+          value: $(params.wrap)
+
+        - name: CLAUDIO_RESULT_FILE
+          value: $(params.result-file)
+
+        - name: NO_COLOR
+          value: $(params.no-color)
+
+        - name: CLAUDIO_OUTPUT_RESULT
+          value: $(params.output-result)
+
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/gcp/application_default_credentials.json
+
+        - name: ENV_SECRETS
+          value: "$(params.env-secrets[*])"
+
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        touch "$(results.output.path)"
+
+        if [[ "$CLAUDIO_OUTPUT_RESULT" == "true" ]]; then
+          export CLAUDIO_RESULT_FILE="$(results.output.path)"
+        fi
+
+        if [[ "$(workspaces.source.bound)" == "true" ]]; then
+          cd "$(workspaces.source.path)"
+        fi
+
+        load_secret() {
+          local secret_name="$1"
+          local key value tmpfile
+
+          echo "Loading secret: ${secret_name}"
+
+          tmpfile=$(mktemp)
+          trap "rm -f '$tmpfile'" RETURN
+
+          kubectl get secret "${secret_name}" \
+            -o go-template='{{range $k,$v := .data}}{{printf "%s\x00%s\x00" $k ($v|base64decode)}}{{end}}' \
+            > "$tmpfile" || {
+            echo "ERROR: failed loading ${secret_name}" >&2
+            exit 1
+          }
+
+          while IFS= read -r -d '' key && IFS= read -r -d '' value; do
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+            export "$key=$value"
+          done < "$tmpfile"
+        }
+
+        read -ra secrets <<< "$ENV_SECRETS"
+
+        if [[ ${#secrets[@]} -gt 0 && -n "${secrets[0]}" ]]; then
+          command -v kubectl >/dev/null || {
+            echo "ERROR: kubectl not found but ENV_SECRETS requires it"
+            exit 1
+          }
+
+          for secret in "${secrets[@]}"; do
+            [[ -n "$secret" ]] || continue
+            load_secret "$secret"
+          done
+        fi
+
+        entrypoint.sh \
+          -p "$CLAUDIO_PROMPT" \
+          "$@"


### PR DESCRIPTION
## Summary
- Add output-result param to the Tekton task that wires CLAUDIO_RESULT_FILE to the Tekton result path when true
- Add CLAUDIO_VALIDATE_RESULT env var to entrypoint (default true) - when false, skips SUCCESS/FAILURE verdict extraction and writes raw evaluation output
- Enables downstream Tekton tasks (e.g. slack-webhook-notification) to consume Claudio evaluation output

## Test plan
- [ ] Run with output-result false (default) - result should be empty, no evaluation triggered via this path
- [ ] Run with output-result true and default evaluation prompt - result should contain SUCCESS/FAILURE verdict
- [ ] Run with output-result true and custom CLAUDIO_EVALUATION_PROMPT + CLAUDIO_VALIDATE_RESULT=false - result should contain raw evaluation output