### PR TITLE
feat: add opt-in Tekton result output

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,11 +32,11 @@ RUN set -eux; \
     tar -xzf gcloud.tar.gz -C /opt;
 
 # Claudio Skills
-ARG CS_REF_TYPE
-ARG CS_REF
+ARG CS_REF_TYPE=""
+ARG CS_REF=""
 # CS_CACHE_KEY is the resolved commit SHA — changing it invalidates the layer
 # cache so we always get fresh content when the remote ref updates.
-ARG CS_CACHE_KEY
+ARG CS_CACHE_KEY=""
 ENV CS_REPO https://github.com/aipcc-cicd/claudio-skills.git
 RUN echo "cs-cache-key: ${CS_CACHE_KEY}" \
  && set -eux; \
@@ -81,9 +81,9 @@ COPY scripts/ entrypoint.sh /usr/local/bin/
 
 # Claudio Skills
 COPY --from=preparer /claudio-skills /home/claudio/claudio-skills
-ARG CS_REF_TYPE
-ARG CS_REF
-ARG CS_CACHE_KEY
+ARG CS_REF_TYPE=""
+ARG CS_REF=""
+ARG CS_CACHE_KEY=""
 RUN echo "cs-cache-key: ${CS_CACHE_KEY}" \
  && if [ "${CS_REF_TYPE}" = "pr" ]; then \
         claude plugin marketplace add /home/claudio/claudio-skills; \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,9 @@ fi
 
 ADC_PATH="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
 CLAUDIO_RESULT_FILE="${CLAUDIO_RESULT_FILE:-}"
-CLAUDIO_EVALUATION_PROMPT="${CLAUDIO_EVALUATION_PROMPT:-$(cat <<'EOF'
+CLAUDIO_VALIDATE_RESULT="${CLAUDIO_VALIDATE_RESULT:-true}"
+# CLAUDIO_EVALUATION_PROMPT and CLAUDIO_EVALUATION_MODEL are deprecated names, kept for backwards compatibility
+CLAUDIO_OUTPUT_PROMPT="${CLAUDIO_OUTPUT_PROMPT:-${CLAUDIO_EVALUATION_PROMPT:-$(cat <<'EOF'
 Read this Claude Code session log and determine whether the task completed successfully.
 
 Your entire response must be a single word or line — no preamble, no explanation:
@@ -27,7 +29,7 @@ Rules for FAILURE:
 - the final state is uncertain
 - the task could not be verified as complete
 EOF
-)}"
+)}}"
 
 ###################
 #### Functions ####
@@ -191,23 +193,27 @@ if [ -n "${CLAUDIO_RESULT_FILE}" ] && [ -s "${CLAUDIO_LOG_FILE:-}" ]; then
 
   eval_output=""
   if ! eval_output=$(tail -c "${CLAUDIO_RESULT_MAX_CHARS:-50000}" "${CLAUDIO_LOG_FILE}" | \
-    claude -p "${CLAUDIO_EVALUATION_PROMPT}" \
-      --model "${CLAUDIO_EVALUATION_MODEL:-claude-haiku-4-5-20251001}" \
+    claude -p "${CLAUDIO_OUTPUT_PROMPT}" \
+      --model "${CLAUDIO_OUTPUT_MODEL:-${CLAUDIO_EVALUATION_MODEL:-claude-haiku-4-5-20251001}}" \
       --no-session-persistence)
   then
     echo "ERROR: Failed to evaluate task result"
     exit 1
   fi
 
-  # Extract the verdict line — models sometimes wrap it in extra text
-  verdict=$(echo "$eval_output" | grep -oE '^(SUCCESS|FAILURE: .+)' | head -n1)
-  if [ -z "$verdict" ]; then
-    verdict=$(echo "$eval_output" | grep -oE '(SUCCESS|FAILURE: .+)' | head -n1)
-  fi
-  echo "${verdict:-$eval_output}" > "${CLAUDIO_RESULT_FILE}"
+  if [[ "$CLAUDIO_VALIDATE_RESULT" == "true" ]]; then
+    # Extract the verdict line — models sometimes wrap it in extra text
+    verdict=$(echo "$eval_output" | grep -oE '^(SUCCESS|FAILURE: .+)' | head -n1)
+    if [ -z "$verdict" ]; then
+      verdict=$(echo "$eval_output" | grep -oE '(SUCCESS|FAILURE: .+)' | head -n1)
+    fi
+    echo "${verdict:-$eval_output}" > "${CLAUDIO_RESULT_FILE}"
 
-  validate_result
-  exit $?
+    validate_result
+    exit $?
+  else
+    echo "$eval_output" > "${CLAUDIO_RESULT_FILE}"
+  fi
 fi
 
 exit 0

--- a/integrations/tekton/claudio.yml
+++ b/integrations/tekton/claudio.yml
@@ -95,6 +95,11 @@ spec:
       default: ""
       description: Disable ANSI colors ("1")
 
+    - name: output-result
+      type: string
+      default: "false"
+      description: Write evaluation output to the Tekton result ("true" to enable)
+
     # Credentials
     - name: gcp-credentials
       type: string
@@ -118,6 +123,13 @@ spec:
       default: []
       description: List of Kubernetes Secrets to load as env vars
 
+  results:
+    - name: output
+      description: >
+        Populated when output-result is "true". Uses CLAUDIO_OUTPUT_PROMPT
+        to process the session (default: SUCCESS/FAILURE verdict;
+        override with a custom prompt for different output like summaries).
+
   workspaces:
     - name: source
       optional: true
@@ -129,7 +141,7 @@ spec:
 
   steps:
     - name: run
-      image: quay.io/aipcc-cicd/claudio:v0.7.3
+      image: ttl.sh/claudio-test:8h
 
       args:
         - $(params.extra-args[*])
@@ -162,6 +174,9 @@ spec:
         - name: NO_COLOR
           value: $(params.no-color)
 
+        - name: CLAUDIO_OUTPUT_RESULT
+          value: $(params.output-result)
+
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secrets/gcp/application_default_credentials.json
 
@@ -171,6 +186,12 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
+
+        touch "$(results.output.path)"
+
+        if [[ "$CLAUDIO_OUTPUT_RESULT" == "true" ]]; then
+          export CLAUDIO_RESULT_FILE="$(results.output.path)"
+        fi
 
         if [[ "$(workspaces.source.bound)" == "true" ]]; then
           cd "$(workspaces.source.path)"


### PR DESCRIPTION
## Summary
- Add `output-result` param to the Tekton task that wires `CLAUDIO_RESULT_FILE` to the Tekton result path when `true`
- Add `CLAUDIO_VALIDATE_RESULT` env var to entrypoint (default `true`) - when `false`, skips SUCCESS/FAILURE verdict extraction and writes raw evaluation output
- Enables downstream Tekton tasks (e.g. slack-webhook-notification) to consume Claudio evaluation output

## Usage

By default, the Tekton result is empty. To opt-in, set `output-result: "true"` on the task:

```yaml
- name: claudio-troubleshoot
  params:
    - name: prompt
      value: "Analyze why this pipeline failed"
    - name: output-result
      value: "true"
  taskRef:
    params:
      - name: bundle
        value: quay.io/aipcc-cicd/claudio-tekton:v0.8.0
      - name: name
        value: claudio
      - name: kind
        value: Task
    resolver: bundles
```

This runs a second Claude call (haiku) against the session log using `CLAUDIO_EVALUATION_PROMPT`, and writes the result to the Tekton result `output`. Downstream tasks can reference it via `$(tasks.claudio-troubleshoot.results.output)`.

### Custom evaluation prompt

By default the evaluation produces a `SUCCESS`/`FAILURE: <reason>` verdict. To get a custom summary instead (e.g. for Slack notifications), override the evaluation prompt and disable validation:

```yaml
- name: extra-args
  value:
    - --env
    - CLAUDIO_VALIDATE_RESULT=false
    - --env
    - CLAUDIO_EVALUATION_PROMPT=Summarize this session in 1-2 sentences for a Slack notification.
```

## Test plan
- [ ] Run with `output-result: "false"` (default) - result should be empty, no evaluation triggered via this path
- [ ] Run with `output-result: "true"` and default evaluation prompt - result should contain SUCCESS/FAILURE verdict
- [ ] Run with `output-result: "true"` and custom `CLAUDIO_EVALUATION_PROMPT` + `CLAUDIO_VALIDATE_RESULT=false` - result should contain raw evaluation output