### PR TITLE
Add CI smoke test for container image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,39 @@ jobs:
         name: claudio-${{ matrix.arch }}
         path: claudio-${{ matrix.arch }}.tar
 
+  smoke-test:
+    name: Smoke test (${{ matrix.arch }})
+    needs: build-and-upload
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+
+    - name: Download image
+      uses: actions/download-artifact@v8
+      with:
+        name: claudio-${{ matrix.arch }}
+
+    - name: Load image
+      run: |
+        LOADED=$(podman load -i claudio-${{ matrix.arch }}.tar | sed -n 's/^Loaded image: //p')
+        podman tag "${LOADED}" smoke-test:latest
+
+    - name: Run smoke test
+      run: make smoke-test IMAGE_NAME=smoke-test:latest
+
   combine-artifacts:
     name: Combine artifacts
     needs: build-and-upload

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ CS_CACHE_KEY ?= $(shell $(CS_CACHE_KEY_CMD))
 CS_BUILD_ARGS = --build-arg CS_REF=$(CS_REF) --build-arg CS_REF_TYPE=$(CS_REF_TYPE) --build-arg CS_CACHE_KEY=$(CS_CACHE_KEY)
 
 # Build actions
-.PHONY: oci-build oci-save oci-load oci-push-arch oci-manifest-build oci-manifest-push oci-tag oci-push
+.PHONY: oci-build oci-save oci-load oci-push-arch oci-manifest-build oci-manifest-push oci-tag oci-push smoke-test
 
 oci-build:
 	${CONTAINER_MANAGER} build $(CS_BUILD_ARGS) -t $(IMAGE_NAME) .
@@ -72,4 +72,9 @@ oci-tag:
 
 oci-push:
 	${CONTAINER_MANAGER} push $(IMAGE_NAME)
+
+smoke-test:
+	@echo "=== Smoke testing $(IMAGE_NAME) ==="
+	${CONTAINER_MANAGER} run --rm -v $(CURDIR)/scripts/smoke-test.sh:/tmp/smoke-test.sh:ro \
+		--entrypoint bash $(IMAGE_NAME) /tmp/smoke-test.sh
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+FAIL=0
+
+check() {
+	out=$(eval "$2" 2>&1)
+	if [ $? -eq 0 ]; then
+		echo "PASS: $1"
+	else
+		echo "FAIL: $1"
+		echo "$out"
+		FAIL=1
+	fi
+}
+
+check "claude --version" "claude --version"
+check "gcloud --version" "gcloud --version"
+
+for bin in skopeo podman git jq python3; do
+	check "$bin on PATH" "command -v $bin"
+done
+
+check "entrypoint.sh syntax" "bash -n /usr/local/bin/entrypoint.sh"
+check "claudio-plugin installed" "claude plugin list 2>&1 | grep -q claudio-plugin"
+
+for script in /usr/local/bin/pt-manager.sh /usr/local/bin/stream-claude.py; do
+	check "$script executable" "test -x $script"
+done
+
+exit $FAIL


### PR DESCRIPTION
## Summary
- Adds a `smoke-test` job to the Build workflow that runs after image build on every PR and push to main
- Adds a `make smoke-test` Makefile target for local use
- Checks: claude/gcloud versions, key binaries on PATH, entrypoint syntax, claudio-plugin installed, helper scripts executable

Closes AIPCC-17957

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new smoke test step to the release pipeline to validate the built container image before it is considered ready.
  * Added a new smoke-test command that runs a series of runtime checks, including tool availability, version checks, script validation, and plugin presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->