### PR TITLE
feat: add yq to container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -77,6 +77,11 @@ RUN set -eux; \
     /opt/google-cloud-sdk/install.sh -q; \
     ln -s /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud;
 
+# yq (mikefarah)
+ENV YQ_V 4.53.3
+RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_V}/yq_linux_${TARGETARCH}" \
+    -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+
 # Conf
 COPY conf/ ${HOME}/
 COPY scripts/ entrypoint.sh /usr/local/bin/

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,20 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "aipcc-cicd/claudio-skills",
       "autoReplaceStringTemplate": "CS_REF  ?= {{newValue}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Update mikefarah/yq version",
+      "managerFilePatterns": [
+        "Containerfile"
+      ],
+      "matchStrings": [
+        "ENV\\s+YQ_V\\s+(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "mikefarah/yq",
+      "extractVersionTemplate": "^v(?<version>.+)$",
+      "autoReplaceStringTemplate": "ENV YQ_V {{newValue}}"
     }
   ],
   "packageRules": []

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -15,7 +15,7 @@ check() {
 check "claude --version" "claude --version"
 check "gcloud --version" "gcloud --version"
 
-for bin in skopeo podman git jq python3; do
+for bin in skopeo podman git jq yq python3; do
 	check "$bin on PATH" "command -v $bin"
 done
 


### PR DESCRIPTION
Bakes mikefarah/yq v4.53.3 into the container image so downstream skills (e.g. branch-product) don't need to curl-install it at runtime. Adds yq to the smoke test checklist.

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `yq` to the container image so it’s available out of the box.

* **Tests**
  * Updated the smoke test to verify `yq` is present alongside the other required command-line tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->