### PR TITLE
revert: remove yq from container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -77,11 +77,6 @@ RUN set -eux; \
     /opt/google-cloud-sdk/install.sh -q; \
     ln -s /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud;
 
-# yq (mikefarah)
-ENV YQ_V 4.53.3
-RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_V}/yq_linux_${TARGETARCH}" \
-    -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
-
 # Conf
 COPY conf/ ${HOME}/
 COPY scripts/ entrypoint.sh /usr/local/bin/

--- a/renovate.json
+++ b/renovate.json
@@ -39,20 +39,6 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "aipcc-cicd/claudio-skills",
       "autoReplaceStringTemplate": "CS_REF  ?= {{newValue}}"
-    },
-    {
-      "customType": "regex",
-      "description": "Update mikefarah/yq version",
-      "managerFilePatterns": [
-        "Containerfile"
-      ],
-      "matchStrings": [
-        "ENV\\s+YQ_V\\s+(?<currentValue>\\d+\\.\\d+\\.\\d+)"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "mikefarah/yq",
-      "extractVersionTemplate": "^v(?<version>.+)$",
-      "autoReplaceStringTemplate": "ENV YQ_V {{newValue}}"
     }
   ],
   "packageRules": []

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -15,7 +15,7 @@ check() {
 check "claude --version" "claude --version"
 check "gcloud --version" "gcloud --version"
 
-for bin in skopeo podman git jq yq python3; do
+for bin in skopeo podman git jq python3; do
 	check "$bin on PATH" "command -v $bin"
 done
 


### PR DESCRIPTION
Reverts #170 — yq will be provided via the claudio-skills `tools/install.sh` runtime pattern instead of being baked into the base image, per review feedback from Jose and Jakub.

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the bundled `yq` command-line utility from the container image.
  * Updated environment validation to no longer require `yq`.
  * Removed automated version tracking for the bundled utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->