### PR TITLE
chore(deps): update dependency aipcc-cicd/claudio-skills to v0.6.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ARTIFACT_NAME ?= claudio
 # Claudio skills — ref type (branch, tag, or pr) and ref value.
 # Override for development: CS_REF_TYPE=branch CS_REF=main
 CS_REF_TYPE  ?= tag
-CS_REF  ?= v0.6.5
+CS_REF  ?= v0.6.6
 CS_REPO ?= https://github.com/aipcc-cicd/claudio-skills.git
 # Resolve the remote HEAD SHA for the skills ref so the build cache
 # invalidates automatically when the PR/branch gets new commits.


### PR DESCRIPTION
Bump claudio-skills from v0.6.5 to v0.6.6. Adds the yq install script which pt-manager.sh runs at image build time.

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default build tooling reference to the latest skills release.
  - Builds now use refreshed build resources, helping maintain consistency and reliability across generated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->