### PR TITLE
Update claudio-skills references to productization-skills

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -37,15 +37,15 @@ ARG CS_REF
 # CS_CACHE_KEY is the resolved commit SHA — changing it invalidates the layer
 # cache so we always get fresh content when the remote ref updates.
 ARG CS_CACHE_KEY
-ENV CS_REPO https://github.com/aipcc-cicd/claudio-skills.git
+ENV CS_REPO https://github.com/opendatahub-io/productization-skills.git
 RUN echo "cs-cache-key: ${CS_CACHE_KEY}" \
  && set -eux; \
     if [ "${CS_REF_TYPE}" = "pr" ]; then \
-        git clone "${CS_REPO}"; \
-        git -C claudio-skills fetch --depth 1 origin "pull/${CS_REF}/head"; \
-        git -C claudio-skills checkout FETCH_HEAD; \
+        git clone "${CS_REPO}" productization-skills; \
+        git -C productization-skills fetch --depth 1 origin "pull/${CS_REF}/head"; \
+        git -C productization-skills checkout FETCH_HEAD; \
     fi; \
-    mkdir -p claudio-skills;
+    mkdir -p productization-skills;
 
 # Claudio image
 FROM registry.access.redhat.com/ubi10/python-312-minimal@sha256:3a571c8031770f7e6f032cee78f0d4cba1c117205660fdcaf446f58545a98a6b
@@ -83,17 +83,17 @@ COPY conf/ ${HOME}/
 COPY scripts/ entrypoint.sh /usr/local/bin/
 
 # Claudio Skills
-COPY --from=preparer /claudio-skills /home/claudio/claudio-skills
+COPY --from=preparer /productization-skills /home/claudio/productization-skills
 ARG CS_REF_TYPE
 ARG CS_REF
 ARG CS_CACHE_KEY
 RUN echo "cs-cache-key: ${CS_CACHE_KEY}" \
  && if [ "${CS_REF_TYPE}" = "pr" ]; then \
-        claude plugin marketplace add /home/claudio/claudio-skills; \
+        claude plugin marketplace add /home/claudio/productization-skills; \
     else \
-        claude plugin marketplace add aipcc-cicd/claudio-skills@${CS_REF}; \
+        claude plugin marketplace add opendatahub-io/productization-skills@${CS_REF}; \
     fi; \
-    claude plugin install --scope user claudio-plugin; \
+    claude plugin install --scope user productization-plugin; \
     pt-manager.sh
 
 # Claudio

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,8 @@ ARTIFACT_NAME ?= claudio
 
 # Claudio skills — ref type (branch, tag, or pr) and ref value.
 # Override for development: CS_REF_TYPE=branch CS_REF=main
-# TODO(#178): switch back to CS_REF_TYPE=tag once productization-skills has its first release tag
-CS_REF_TYPE  ?= branch
-CS_REF  ?= main
+CS_REF_TYPE  ?= tag
+CS_REF  ?= v0.8.1
 CS_REPO ?= https://github.com/opendatahub-io/productization-skills.git
 # Resolve the remote HEAD SHA for the skills ref so the build cache
 # invalidates automatically when the PR/branch gets new commits.

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,9 @@ ARTIFACT_NAME ?= claudio
 
 # Claudio skills — ref type (branch, tag, or pr) and ref value.
 # Override for development: CS_REF_TYPE=branch CS_REF=main
-CS_REF_TYPE  ?= tag
-CS_REF  ?= v0.7.0
+# TODO(#178): switch back to CS_REF_TYPE=tag once productization-skills has its first release tag
+CS_REF_TYPE  ?= branch
+CS_REF  ?= main
 CS_REPO ?= https://github.com/opendatahub-io/productization-skills.git
 # Resolve the remote HEAD SHA for the skills ref so the build cache
 # invalidates automatically when the PR/branch gets new commits.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ARTIFACT_NAME ?= claudio
 # Override for development: CS_REF_TYPE=branch CS_REF=main
 CS_REF_TYPE  ?= tag
 CS_REF  ?= v0.7.0
-CS_REPO ?= https://github.com/aipcc-cicd/claudio-skills.git
+CS_REPO ?= https://github.com/opendatahub-io/productization-skills.git
 # Resolve the remote HEAD SHA for the skills ref so the build cache
 # invalidates automatically when the PR/branch gets new commits.
 CS_CACHE_KEY_CMD = $(if $(filter pr,$(CS_REF_TYPE)), \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Available targets:
 
 ## Productization Skills Reference
 
-During the image build, claudio clones [productization-skills](https://github.com/opendatahub-io/productization-skills) into `/home/claudio/productization-skills/` and:
+For PR builds (`CS_REF_TYPE=pr`), the image build clones [productization-skills](https://github.com/opendatahub-io/productization-skills) into `/home/claudio/productization-skills/`. For branch and tag builds, it adds the remote marketplace at the selected `CS_REF`. Both paths then:
 
 1. **Fetches the specified git ref** — a branch, tag, or pull request head
 2. **Runs tool installers** — iterates over `productization-plugin/tools/*/install.sh` and executes each one (e.g. jq, kubectl)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 OCI image to make claude code portable; the model is being setup to use through Google Vertex AI API.
 
-Additional functionality is provided through the [claudio-skills marketplace](https://github.com/aipcc-cicd/claudio-skills).
+Additional functionality is provided through the [productization-skills marketplace](https://github.com/opendatahub-io/productization-skills).
 
 # Build
 
@@ -34,13 +34,13 @@ Available targets:
 - `oci-manifest-build` - Create multi-arch manifest from arch-tagged images
 - `oci-manifest-push` - Push manifest to registry
 
-## Claudio Skills Reference
+## Productization Skills Reference
 
-During the image build, claudio clones [claudio-skills](https://github.com/aipcc-cicd/claudio-skills) into `/home/claudio/claudio-skills/` and:
+During the image build, claudio clones [productization-skills](https://github.com/opendatahub-io/productization-skills) into `/home/claudio/productization-skills/` and:
 
 1. **Fetches the specified git ref** — a branch, tag, or pull request head
-2. **Runs tool installers** — iterates over `claudio-plugin/tools/*/install.sh` and executes each one (e.g. jq, kubectl)
-3. **Installs Python dependencies** — installs packages from `claudio-plugin/tools/python/*-requirements.txt`
+2. **Runs tool installers** — iterates over `productization-plugin/tools/*/install.sh` and executes each one (e.g. jq, kubectl)
+3. **Installs Python dependencies** — installs packages from `productization-plugin/tools/python/*-requirements.txt`
 4. **Generates plugin configs** — registers skills and tools so Claude can discover them at runtime
 
 The git ref is controlled by two build args:
@@ -58,11 +58,11 @@ CS_REF_TYPE=tag CS_REF=v0.1.0 make oci-build
 CS_REF_TYPE=pr CS_REF=9 make oci-build
 ```
 
-### Testing claudio-skills changes in downstream images
+### Testing productization-skills changes in downstream images
 
-When developing changes to claudio-skills that affect a downstream image (e.g. aipcc-claudio), you can test end-to-end before merging:
+When developing changes to productization-skills that affect a downstream image (e.g. aipcc-claudio), you can test end-to-end before merging:
 
-1. Open a PR in claudio-skills (e.g. PR #9)
+1. Open a PR in productization-skills (e.g. PR #9)
 2. Build the claudio base image referencing that PR:
    ```bash
    CS_REF_TYPE=pr CS_REF=9 make oci-build
@@ -179,7 +179,7 @@ Downstream projects can extend this template to add their own secret management.
 Releases are fully automated via GitHub Actions — no manual commits or version bumps needed.
 
 1. Go to **Actions** → **Release** → **Run workflow**
-2. Enter the version (e.g. `v0.8.0`) and the claudio-skills tag to pin (e.g. `v0.5.5`)
+2. Enter the version (e.g. `v0.8.0`) and the productization-skills tag to pin (e.g. `v0.5.5`)
 3. Click **Run workflow**
 
 The workflow builds multi-arch images, pushes to Quay (`quay.io/aipcc-cicd/claudio:v0.8.0`), creates a git tag, and publishes a GitHub Release with auto-generated notes.

--- a/blog/claudio-intro.md
+++ b/blog/claudio-intro.md
@@ -20,7 +20,7 @@ So we put it in a container.
 
 ## What Claudio actually is
 
-[Claudio](https://github.com/aipcc-cicd/claudio) is an open-source OCI image, built on Red Hat UBI 10, that packages Claude Code with everything it needs to work on its own. Authentication (we use Google Vertex AI), a bunch of DevOps CLI tools — kubectl, glab, skopeo, jq, AWS CLI — and a plugin system called [claudio-skills](https://github.com/aipcc-cicd/claudio-skills) that gives the agent actual capabilities in specific domains.
+[Claudio](https://github.com/aipcc-cicd/claudio) is an open-source OCI image, built on Red Hat UBI 10, that packages Claude Code with everything it needs to work on its own. Authentication (we use Google Vertex AI), a bunch of DevOps CLI tools — kubectl, glab, skopeo, jq, AWS CLI — and a plugin system called [productization-skills](https://github.com/opendatahub-io/productization-skills) that gives the agent actual capabilities in specific domains.
 
 You can run it locally with `podman run`, deploy it as a Kubernetes CronJob, drop it into a GitLab CI pipeline. Same image everywhere. That's the whole point.
 
@@ -36,7 +36,7 @@ So when Claudio analyzes a GitLab pipeline failure, it's not inventing CLI comma
 
 This is what makes us comfortable running it unattended. You get the flexibility of an AI agent (it can reason, adapt, handle things you didn't anticipate) without the fragility (because the important stuff is locked down in code that we've tested).
 
-The [claudio-skills repo](https://github.com/aipcc-cicd/claudio-skills) currently has skills for CI/CD analysis, release orchestration, log analysis, Slack, branch management, and Jira. And adding a new one is honestly pretty easy — you create a directory with a markdown file and some scripts. No SDK, no framework. The markdown tells the agent what the skill can do and how to use the scripts. Think of it as a very detailed runbook, except the AI actually follows it (most of the time).
+The [productization-skills repo](https://github.com/opendatahub-io/productization-skills) currently has skills for CI/CD analysis, release orchestration, log analysis, Slack, branch management, and Jira. And adding a new one is honestly pretty easy — you create a directory with a markdown file and some scripts. No SDK, no framework. The markdown tells the agent what the skill can do and how to use the scripts. Think of it as a very detailed runbook, except the AI actually follows it (most of the time).
 
 ## What we actually do with it
 
@@ -79,7 +79,7 @@ That's exactly what we do. The upstream Claudio image is generic. Our team-speci
 The project is open source under Apache 2.0:
 
 - [Claudio](https://github.com/aipcc-cicd/claudio) — base image, build instructions, wrapper script, CI templates
-- [Claudio Skills](https://github.com/aipcc-cicd/claudio-skills) — the skill marketplace with examples and contribution guidelines
+- [Productization Skills](https://github.com/opendatahub-io/productization-skills) — the skill marketplace with examples and contribution guidelines
 
 If you're spending hours each week on DevOps work that needs judgment — not just execution — it might be worth a look. And if you build something with it, we'd love to hear about it.
 

--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
       "managerFilePatterns": ["Makefile"],
       "matchStrings": ["CS_REF\\s+\\?=\\s+(?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "aipcc-cicd/claudio-skills",
+      "depNameTemplate": "opendatahub-io/productization-skills",
       "autoReplaceStringTemplate": "CS_REF  ?= {{newValue}}"
     }
   ],

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -20,7 +20,7 @@ for bin in skopeo podman git jq python3; do
 done
 
 check "entrypoint.sh syntax" "bash -n /usr/local/bin/entrypoint.sh"
-check "claudio-plugin installed" "claude plugin list 2>&1 | grep -q claudio-plugin"
+check "productization-plugin installed" "claude plugin list 2>&1 | grep -q productization-plugin"
 
 for script in /usr/local/bin/pt-manager.sh /usr/local/bin/stream-claude.py; do
 	check "$script executable" "test -x $script"


### PR DESCRIPTION
## Summary

- Update all `claudio-skills` → `productization-skills` references
- Update all `claudio-plugin` → `productization-plugin` references
- Point to new repo: `opendatahub-io/productization-skills`

## Files changed

| File | Change |
|---|---|
| `Containerfile` | Repo URL, directory paths, marketplace add, plugin install |
| `Makefile` | `CS_REPO` URL |
| `renovate.json` | `depNameTemplate` for skills version tracking |
| `scripts/smoke-test.sh` | Plugin name check |
| `README.md` | All skills/plugin references and URLs |
| `blog/claudio-intro.md` | Skills repo URLs |

## Context

Follow-up from AIPCC-19466. The skills repo has been migrated from `aipcc-cicd/claudio-skills` to `opendatahub-io/productization-skills` with a full rebrand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated product naming and repository references to Productization Skills throughout the README and introductory blog content.
  * Refreshed installation, testing, plugin, and release guidance.

* **Maintenance**
  * Updated container and build configuration to use the Productization Skills repository and the v0.8.1 release.
  * Updated automated release tracking and smoke tests for the productization plugin.
  * Aligned installation and validation workflows with the updated product naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->